### PR TITLE
Changed example so that it builds properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ Temporary Items
 *.skv
 /test/a.out
 /test/*.out
-/test/*.o
 /test/*.skv
 /test/*.db
 /test/*.out.dSYM

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ Temporary Items
 *.skv
 /test/a.out
 /test/*.out
+/test/*.o
 /test/*.skv
 /test/*.db
 /test/*.out.dSYM

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,3 +1,2 @@
-cc -c test.c -o test.o
 cc -o ./a.out ./test.c ../target/debug/libsurrealdb_c.a -lpthread -lm
 ./a.out

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,1 +1,3 @@
-cc -g -L../target/debug -lsurrealdb_c -lpthread test.c && ./a.out
+cc -c test.c -o test.o
+cc -o ./a.out ./test.c ../target/debug/libsurrealdb_c.a -lpthread -lm
+./a.out


### PR DESCRIPTION
The current main branch has these problems with linking:

![image](https://github.com/user-attachments/assets/0d551aac-0cc4-4e8c-bd01-22819ce850fe)
However, these problems only happend when dynamic linking and if the examples are linked with the static library (and the linking with math -lm), It works properly without this linking issues.


The only weird output is this note:

![image](https://github.com/user-attachments/assets/5beca26b-1345-49bd-b355-ba58c2100394)
