### PR TITLE
SurrealDB v3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,8 @@ Output.txt
 Output.log
 .output.txt
 
-# ThirdPary directory.
+# ThirdParty directory.
 ThirdParty/
+
+# Local tools installed by scripts/install-prereqs.sh
+.local/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,10 @@ elseif(APPLE)
     set_target_properties(surrealdb_c PROPERTIES
         INTERFACE_LINK_LIBRARIES "-framework Security;-framework SystemConfiguration;-framework CoreFoundation;-framework IOKit;-lobjc"
     )
+elseif(UNIX)
+    set_target_properties(surrealdb_c PROPERTIES
+        INTERFACE_LINK_LIBRARIES "m;dl;pthread;rt"
+    )
 endif()
 
 if(_sdb_is_multi_config AND NOT _sdb_force_release)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,10 +233,14 @@ add_dependencies(surrealdb_c rust_lib)
 # This allows examples and tests to use surrealdb::surrealdb_c just like external consumers
 add_library(surrealdb::surrealdb_c ALIAS surrealdb_c)
 
-# Windows system libraries required by the Rust library
+# Platform-specific system libraries required by the Rust library
 if(WIN32)
     set_target_properties(surrealdb_c PROPERTIES
         INTERFACE_LINK_LIBRARIES "ws2_32;userenv;bcrypt;ntdll;pdh;netapi32;iphlpapi;psapi;propsys;runtimeobject;secur32;powrprof"
+    )
+elseif(APPLE)
+    set_target_properties(surrealdb_c PROPERTIES
+        INTERFACE_LINK_LIBRARIES "-framework Security;-framework SystemConfiguration;-framework CoreFoundation;-framework IOKit;-lobjc"
     )
 endif()
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,14 +19,17 @@ dependencies = [
 
 [[package]]
 name = "affinitypool"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dde2a385b82232b559baeec740c37809051c596f9b56e7da0d0da2c8e8f54f6"
+checksum = "7a58b64a64aecad4ba7f2ccf0f79115f5d2d184b1e55307f78c20be07adc6633"
 dependencies = [
- "async-channel",
+ "crossbeam",
+ "libc",
  "num_cpus",
- "thiserror 1.0.69",
+ "parking_lot",
+ "thiserror 2.0.18",
  "tokio",
+ "winapi",
 ]
 
 [[package]]
@@ -141,19 +144,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "any_ascii"
-version = "0.3.3"
+name = "anyhow"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c6333e01ba7235575b6ab53e5af10f1c327927fd97c36462917e289557ea64"
-
-[[package]]
-name = "approx"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
-dependencies = [
- "num-traits",
-]
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "approx"
@@ -162,15 +156,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "ar_archive_writer"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c269894b6fe5e9d7ada0cf69b5bf847ff35bc25fc271f08e1d080fce80339a"
-dependencies = [
- "object",
 ]
 
 [[package]]
@@ -219,15 +204,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ascii-canvas"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
-dependencies = [
- "term",
-]
-
-[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,37 +216,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-executor"
-version = "1.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
 name = "async-graphql"
-version = "7.1.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b75c5a43a58890d6dcc02d03952456570671332bb0a5a947b1f09c699912a5"
+checksum = "1057a9f7ccf2404d94571dec3451ade1cb524790df6f1ada0d19c2a49f6b0f40"
 dependencies = [
  "async-graphql-derive",
  "async-graphql-parser",
  "async-graphql-value",
+ "async-io",
  "async-trait",
  "asynk-strim",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "fnv",
- "futures-timer",
  "futures-util",
  "http",
- "indexmap 2.13.0",
+ "indexmap",
  "mime",
  "multer",
  "num-traits",
@@ -280,31 +242,31 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "static_assertions_next",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "async-graphql-derive"
-version = "7.1.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c266ec9a094bbf2d088e016f71aa8d3be7f18c7343b2f0fe6d0e6c1e78977ea"
+checksum = "2e6cbeadc8515e66450fba0985ce722192e28443697799988265d86304d7cc68"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
- "darling 0.23.0",
+ "darling",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
  "strum",
  "syn 2.0.114",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "async-graphql-parser"
-version = "7.1.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67e2188d3f1299087aa02cfb281f12414905ce63f425dbcfe7b589773468d771"
+checksum = "e64ef70f77a1c689111e52076da1cd18f91834bcb847de0a9171f83624b07fbf"
 dependencies = [
  "async-graphql-value",
  "pest",
@@ -314,21 +276,55 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-value"
-version = "7.1.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527a4c6022fc4dac57b4f03f12395e9a391512e85ba98230b93315f8f45f27fc"
+checksum = "3e3ef112905abea9dea592fc868a6873b10ebd3f983e83308f995d6284e9ba41"
 dependencies = [
  "bytes",
- "indexmap 2.13.0",
+ "indexmap",
  "serde",
  "serde_json",
 ]
 
 [[package]]
-name = "async-task"
-version = "4.7.1"
+name = "async-io"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "async-trait"
@@ -339,17 +335,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
-]
-
-[[package]]
-name = "async_io_stream"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
-dependencies = [
- "futures",
- "pharos",
- "rustc_version",
 ]
 
 [[package]]
@@ -384,10 +369,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "base64"
-version = "0.21.7"
+name = "aws-lc-rs"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.37.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -403,46 +454,42 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bcrypt"
-version = "0.15.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e65938ed058ef47d92cf8b346cc76ef48984572ade631927e9937b5ffc7662c7"
+checksum = "9a0f5948f30df5f43ac29d310b7476793be97c50787e6ef4a63d960a0d0be827"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "blowfish",
- "getrandom 0.2.17",
+ "getrandom 0.3.4",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "bincode"
-version = "1.3.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
+ "bincode_derive",
  "serde",
+ "unty",
 ]
 
 [[package]]
-name = "bit-set"
-version = "0.5.3"
+name = "bincode_derive"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
 dependencies = [
- "bit-vec",
+ "virtue",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bitvec"
@@ -499,6 +546,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bnum"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f781dba93de3a5ef6dc5b17c9958b208f6f3f021623b360fb605ea51ce443f10"
+
+[[package]]
 name = "borsh"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,6 +573,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "boxcar"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
 
 [[package]]
 name = "bumpalo"
@@ -563,20 +622,11 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "castaway"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
-dependencies = [
- "rustversion",
 ]
 
 [[package]]
@@ -587,7 +637,7 @@ checksum = "befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799"
 dependencies = [
  "clap",
  "heck",
- "indexmap 2.13.0",
+ "indexmap",
  "log",
  "proc-macro2",
  "quote",
@@ -605,65 +655,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
 [[package]]
-name = "cedar-policy"
-version = "2.4.2"
+name = "cesu8"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d91e3b10a0f7f2911774d5e49713c4d25753466f9e11d1cd2ec627f8a2dc857"
-dependencies = [
- "cedar-policy-core",
- "cedar-policy-validator",
- "itertools 0.10.5",
- "lalrpop-util",
- "ref-cast",
- "serde",
- "serde_json",
- "smol_str",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "cedar-policy-core"
-version = "2.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd2315591c6b7e18f8038f0a0529f254235fd902b6c217aabc04f2459b0d9995"
-dependencies = [
- "either",
- "ipnet",
- "itertools 0.10.5",
- "lalrpop",
- "lalrpop-util",
- "lazy_static",
- "miette",
- "regex",
- "rustc_lexer",
- "serde",
- "serde_json",
- "serde_with",
- "smol_str",
- "stacker",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "cedar-policy-validator"
-version = "2.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e756e1b2a5da742ed97e65199ad6d0893e9aa4bd6b34be1de9e70bd1e6adc7df"
-dependencies = [
- "cedar-policy-core",
- "itertools 0.10.5",
- "serde",
- "serde_json",
- "serde_with",
- "smol_str",
- "stacker",
- "thiserror 1.0.69",
- "unicode-security",
-]
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -688,7 +689,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -756,10 +757,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -771,10 +791,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -807,6 +843,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,6 +884,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-skiplist"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,6 +913,18 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array 0.14.7",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "crypto-common"
@@ -856,7 +945,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf",
+ "phf 0.11.3",
  "smallvec",
 ]
 
@@ -871,13 +960,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.21.3"
+name = "curve25519-dalek"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -886,22 +992,8 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.114",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -919,33 +1011,23 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
-dependencies = [
- "darling_core 0.21.3",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.114",
 ]
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
+ "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
@@ -959,13 +1041,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
- "serde_core",
 ]
 
 [[package]]
@@ -981,29 +1073,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -1028,12 +1100,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "double-ended-peekable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d05e1c0dbad51b52c38bda7adceef61b9efc2baf04acfe8726a8c4630a6f57"
-
-[[package]]
 name = "dtoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,10 +1115,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.20"
+name = "dunce"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "earcutr"
@@ -1065,18 +1131,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "ena"
-version = "0.14.3"
+name = "elliptic-curve"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "log",
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array 0.14.7",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1090,9 +1206,9 @@ dependencies = [
 
 [[package]]
 name = "endian-type"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+checksum = "869b0adbda23651a9c5c0c3d270aac9fcb52e8622a8f2b17e57802d7791962f2"
 
 [[package]]
 name = "equivalent"
@@ -1145,10 +1261,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastnum"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4089ab2dfd45d8ddc92febb5ca80644389d5ebb954f40231274a3f18341762e2"
+dependencies = [
+ "bnum",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1157,10 +1300,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
+name = "flatbuffers"
+version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags",
+ "rustc_version",
+ "serde",
+]
 
 [[package]]
 name = "float_next_after"
@@ -1188,6 +1336,22 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fst"
@@ -1265,10 +1429,7 @@ version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
- "fastrand",
  "futures-core",
- "futures-io",
- "parking",
  "pin-project-lite",
 ]
 
@@ -1354,6 +1515,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1370,8 +1532,45 @@ dependencies = [
  "num-traits",
  "robust",
  "rstar 0.12.2",
+ "spade",
+]
+
+[[package]]
+name = "geo"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc1a1678e54befc9b4bcab6cd43b8e7f834ae8ea121118b0fd8c42747675b4a"
+dependencies = [
+ "earcutr",
+ "float_next_after",
+ "geo-types",
+ "geographiclib-rs",
+ "i_overlay",
+ "log",
+ "num-traits",
+ "robust",
+ "rstar 0.12.2",
  "serde",
  "spade",
+]
+
+[[package]]
+name = "geo"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3901269ec6d4f6068d3f09e5f02f995bd076398dcd1dfec407cd230b02d11b"
+dependencies = [
+ "float_next_after",
+ "geo-types",
+ "geographiclib-rs",
+ "i_overlay",
+ "log",
+ "num-traits",
+ "rand 0.8.5",
+ "robust",
+ "rstar 0.12.2",
+ "serde",
+ "sif-itree",
 ]
 
 [[package]]
@@ -1380,8 +1579,9 @@ version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24f8647af4005fa11da47cd56252c6ef030be8fa97bdbf355e7dfb6348f0a82c"
 dependencies = [
- "approx 0.5.1",
+ "approx",
  "num-traits",
+ "rayon",
  "rstar 0.10.0",
  "rstar 0.11.0",
  "rstar 0.12.2",
@@ -1427,6 +1627,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "guardian"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1438,7 +1661,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -1516,6 +1739,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "heapless"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1567,6 +1814,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"
@@ -1628,6 +1884,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1647,6 +1909,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -1669,7 +1932,19 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.5",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1678,7 +1953,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -1695,6 +1970,49 @@ dependencies = [
  "tower-service",
  "tracing",
 ]
+
+[[package]]
+name = "i_float"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010025c2c532c8d82e42d0b8bb5184afa449fa6f06c709ea9adcb16c49ae405b"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "i_key_sort"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9190f86706ca38ac8add223b2aed8b1330002b5cdbbce28fb58b10914d38fc27"
+
+[[package]]
+name = "i_overlay"
+version = "4.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413183068e6e0289e18d7d0a1f661b81546e6918d5453a44570b9ab30cbed1b3"
+dependencies = [
+ "i_float",
+ "i_key_sort",
+ "i_shape",
+ "i_tree",
+ "rayon",
+]
+
+[[package]]
+name = "i_shape"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ea154b742f7d43dae2897fcd5ead86bc7b5eefcedd305a7ebf9f69d44d61082"
+dependencies = [
+ "i_float",
+]
+
+[[package]]
+name = "i_tree"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e6d558e6d4c7b82bc51d9c771e7a927862a161a7d87bf2b0541450e0e20915"
 
 [[package]]
 name = "iana-time-zone"
@@ -1830,17 +2148,6 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
@@ -1859,6 +2166,12 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array 0.14.7",
 ]
+
+[[package]]
+name = "integer-encoding"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c00403deb17c3221a1fe4fb571b9ed0370b3dcd116553c77fa294a3d918699"
 
 [[package]]
 name = "ipnet"
@@ -1884,18 +2197,18 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1916,6 +2229,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1927,48 +2272,26 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
+version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
- "base64 0.22.1",
+ "aws-lc-rs",
+ "base64",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "hmac",
  "js-sys",
+ "p256",
+ "p384",
  "pem",
- "ring",
+ "rand 0.8.5",
+ "rsa",
  "serde",
  "serde_json",
+ "sha2",
+ "signature",
  "simple_asn1",
-]
-
-[[package]]
-name = "lalrpop"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
-dependencies = [
- "ascii-canvas",
- "bit-set",
- "ena",
- "itertools 0.11.0",
- "lalrpop-util",
- "petgraph",
- "pico-args",
- "regex",
- "regex-syntax",
- "string_cache",
- "term",
- "tiny-keccak",
- "unicode-xid",
- "walkdir",
-]
-
-[[package]]
-name = "lalrpop-util"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
-dependencies = [
- "regex-automata",
 ]
 
 [[package]]
@@ -1976,14 +2299,17 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "lexicmp"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7378d131ddf24063b32cbd7e91668d183140c4b3906270635a4d633d1068ea5d"
+checksum = "0e8f89da8fd95c4eb6274e914694bea90c7826523b26f2a2fd863d44b9d42c43"
 dependencies = [
- "any_ascii",
+ "deunicode",
 ]
 
 [[package]]
@@ -1997,28 +2323,6 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
-
-[[package]]
-name = "libredox"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
-dependencies = [
- "bitflags",
- "libc",
-]
-
-[[package]]
-name = "linfa-linalg"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e7562b41c8876d3367897067013bb2884cc78e6893f092ecd26b305176ac82"
-dependencies = [
- "ndarray",
- "num-traits",
- "rand 0.8.5",
- "thiserror 1.0.69",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -2048,19 +2352,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lz4"
+version = "1.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20b523e860d03443e98350ceaac5e71c6ba89aea7d960769ec3ce37f4de5af4"
+dependencies = [
+ "lz4-sys",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab6473172471198271ff72e9379150e9dfd70d8e533e0752a27e515b48dd375e"
+dependencies = [
+ "twox-hash",
+]
 
 [[package]]
 name = "mac"
@@ -2097,6 +2420,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2121,29 +2450,6 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
-
-[[package]]
-name = "miette"
-version = "5.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
-dependencies = [
- "miette-derive",
- "once_cell",
- "thiserror 1.0.69",
- "unicode-width",
-]
-
-[[package]]
-name = "miette-derive"
-version = "5.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
 
 [[package]]
 name = "mime"
@@ -2190,36 +2496,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "nanoid"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
-dependencies = [
- "rand 0.8.5",
-]
-
-[[package]]
 name = "ndarray"
-version = "0.15.6"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
 dependencies = [
- "approx 0.4.0",
  "matrixmultiply",
  "num-complex",
  "num-integer",
  "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
  "rawpointer",
 ]
 
 [[package]]
 name = "ndarray-stats"
-version = "0.5.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af5a8477ac96877b5bd1fd67e0c28736c12943aba24eda92b127e036b0c8f400"
+checksum = "9b6e54a8b65764f71827a90ca1d56965ec0c67f069f996477bd493402a901d1f"
 dependencies = [
- "indexmap 1.9.3",
- "itertools 0.10.5",
+ "indexmap",
+ "itertools 0.13.0",
  "ndarray",
  "noisy_float",
  "num-integer",
@@ -2271,6 +2569,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2295,6 +2609,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2315,19 +2640,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.32.2"
+name = "objc2-core-foundation"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "memchr",
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
 name = "object_store"
-version = "0.12.4"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c1be0c6c22ec0817cdc77d3842f721a17fd30ab6965001415b5402a74e6b740"
+checksum = "c2858065e55c148d294a9f3aae3b0fa9458edadb41a108397094566f4e3c0dfb"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2338,7 +2673,7 @@ dependencies = [
  "itertools 0.14.0",
  "parking_lot",
  "percent-encoding",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -2358,6 +2693,46 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "papaya"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f92dd0b07c53a0a0c764db2ace8c541dc47320dad97c2200c2a637ab9dd2328f"
+dependencies = [
+ "equivalent",
+ "seize",
+]
 
 [[package]]
 name = "parking"
@@ -2385,7 +2760,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2429,8 +2804,17 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -2450,33 +2834,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap 2.13.0",
-]
-
-[[package]]
-name = "pharos"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
-dependencies = [
- "futures",
- "rustc_version",
-]
-
-[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros",
- "phf_shared",
+ "phf_macros 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -2485,8 +2860,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -2495,8 +2870,18 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -2505,8 +2890,21 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -2520,14 +2918,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
  "unicase",
 ]
 
 [[package]]
-name = "pico-args"
-version = "0.5.0"
+name = "pin-project"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2540,6 +2961,56 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2572,6 +3043,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2590,20 +3070,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "psl-types"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
-
-[[package]]
-name = "psm"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11f2fedc3b7dafdc2851bc52f277377c5473d378859be234bc7ebb593144d01"
-dependencies = [
- "ar_archive_writer",
- "cc",
-]
 
 [[package]]
 name = "ptr_meta"
@@ -2623,18 +3125,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "quick_cache"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb55a1aa7668676bb93926cd4e9cdfe60f03bb866553bcca9112554911b6d3dc"
-dependencies = [
- "ahash 0.8.12",
- "equivalent",
- "hashbrown 0.14.5",
- "parking_lot",
 ]
 
 [[package]]
@@ -2663,7 +3153,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -2675,6 +3165,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -2684,7 +3175,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2727,9 +3218,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "radix_trie"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+checksum = "3b4431027dcd37fc2a73ef740b5f233aa805897935b8bce0195e41bbf9a3289a"
 dependencies = [
  "endian-type",
  "nibble_vec",
@@ -2837,37 +3328,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "ref-cast"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2897,6 +3357,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "rend"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2907,11 +3373,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-core",
  "futures-util",
@@ -2930,9 +3396,9 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -2945,28 +3411,19 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.5",
 ]
 
 [[package]]
 name = "revision"
-version = "0.10.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f53179a035f881adad8c4d58a2c599c6b4a8325b989c68d178d7a34d1b1e4c"
+checksum = "11c3c8ec8b2be254beb5f8acdd80cdd57b7b5d40988c2ec3d0b7cdb6f7c2829b"
 dependencies = [
- "revision-derive 0.10.0",
-]
-
-[[package]]
-name = "revision"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b8ee532f15b2f0811eb1a50adf10d036e14a6cdae8d99893e7f3b921cb227d"
-dependencies = [
+ "bytes",
  "chrono",
- "geo",
+ "geo 0.31.0",
  "regex",
- "revision-derive 0.11.0",
+ "revision-derive",
  "roaring",
  "rust_decimal",
  "uuid",
@@ -2974,9 +3431,9 @@ dependencies = [
 
 [[package]]
 name = "revision-derive"
-version = "0.10.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0ec466e5d8dca9965eb6871879677bef5590cf7525ad96cae14376efb75073"
+checksum = "76be63634a8b1809e663bc0b975d78f6883c0fadbcce9c52e19b9e421f423357"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2984,14 +3441,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "revision-derive"
-version = "0.11.0"
+name = "rfc6979"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3415e1bc838c36f9a0a2ac60c0fa0851c72297685e66592c44870d82834dfa2"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
+ "hmac",
+ "subtle",
 ]
 
 [[package]]
@@ -3004,7 +3460,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -3057,19 +3513,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rmpv"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a4e1d4b9b938a26d2996af33229f0ca0956c652c1375067f0b45291c1df8417"
-dependencies = [
- "rmp",
-]
-
-[[package]]
 name = "roaring"
-version = "0.10.12"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
+checksum = "8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -3081,6 +3528,26 @@ name = "robust"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "rstar"
@@ -3144,6 +3611,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.114",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rust-stemmers"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3176,15 +3672,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
-name = "rustc_lexer"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86aae0c77166108c01305ee1a36a1e77289d7dc6ca0a3cd91ff4992de2d16a5"
-dependencies = [
- "unicode-xid",
-]
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3212,6 +3699,7 @@ version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -3222,14 +3710,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pki-types"
-version = "1.13.2"
+name = "rustls-native-certs"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3237,9 +3764,10 @@ version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3273,27 +3801,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "schemars"
-version = "0.9.0"
+name = "schannel"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e910108742c57a770f492731f99be216a52fadd361b06c8fb59d74ccc267d2"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3321,6 +3834,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array 0.14.7",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "seize"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3331,12 +3891,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "send_wrapper"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3344,15 +3898,6 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde-content"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3753ca04f350fa92d00b6146a3555e63c55388c9ef2e11e09bce2ff1c0b509c6"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -3381,7 +3926,6 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.0",
  "itoa",
  "memchr",
  "serde",
@@ -3408,37 +3952,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_with"
-version = "3.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.13.0",
- "schemars 0.9.0",
- "schemars 1.2.0",
- "serde_core",
- "serde_json",
- "serde_with_macros",
- "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
-dependencies = [
- "darling 0.21.3",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -3470,6 +3983,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "sif-itree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7f45b8998ced5134fb1d75732c77842a3e888f19c1ff98481822e8fbfbf930b"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3477,6 +3996,16 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3493,7 +4022,7 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -3514,12 +4043,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "smol_str"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
 dependencies = [
  "serde",
 ]
@@ -3562,23 +4085,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "stacker"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1f8b29fb42aafcea4edeeb6b2f2d7ecd0d969c48b4cf0d2e64aafc471dd6e59"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "psm",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "static_assertions_next"
@@ -3588,14 +4108,24 @@ checksum = "d7beae5182595e9a8b683fa98c4317f956c9a2dec3b9716990d20023cc60c766"
 
 [[package]]
 name = "storekey"
-version = "0.5.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c42833834a5d23b344f71d87114e0cc9994766a5c42938f4b50e7b2aef85b2"
+checksum = "bd9a94571bde7369ecaac47cec2e6844642d99166bd452fbd8def74b5b917b2f"
 dependencies = [
- "byteorder",
- "memchr",
- "serde",
- "thiserror 1.0.69",
+ "bytes",
+ "storekey-derive",
+ "uuid",
+]
+
+[[package]]
+name = "storekey-derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6079d53242246522ec982de613c5c952cc7b1380ef2f8622fcdab9bfe73c0098"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3606,7 +4136,7 @@ checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared",
+ "phf_shared 0.11.3",
  "precomputed-hash",
  "serde",
 ]
@@ -3617,8 +4147,8 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
 ]
@@ -3658,135 +4188,193 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surrealdb"
-version = "2.4.1"
-source = "git+https://github.com/surrealdb/surrealdb.git?tag=v2.4.1#c684d3dbc5c3f8d5ca5fedb77d8bf5391f62db52"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18997a4c20c9559461846bff0dad185854c32639407904e2bb97567b4fa6a63"
 dependencies = [
- "arrayvec",
+ "anyhow",
  "async-channel",
- "bincode",
+ "boxcar",
  "chrono",
- "dmp",
  "futures",
- "geo",
  "getrandom 0.3.4",
- "indexmap 2.13.0",
+ "indexmap",
+ "js-sys",
  "path-clean",
- "pharos",
- "reblessive",
  "reqwest",
- "revision 0.11.0",
  "ring",
- "rust_decimal",
  "rustls",
  "rustls-pki-types",
  "semver",
  "serde",
- "serde-content",
  "serde_json",
  "surrealdb-core",
- "thiserror 1.0.69",
+ "surrealdb-types",
  "tokio",
  "tokio-tungstenite",
+ "tokio-tungstenite-wasm",
  "tokio-util",
  "tracing",
- "trice",
  "url",
  "uuid",
+ "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasmtimer",
- "ws_stream_wasm",
+ "web-sys",
 ]
 
 [[package]]
 name = "surrealdb-core"
-version = "2.4.1"
-source = "git+https://github.com/surrealdb/surrealdb.git?tag=v2.4.1#c684d3dbc5c3f8d5ca5fedb77d8bf5391f62db52"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470a61158ca8b4e774f8be3a8fbe1393bd33c026d9025a3db8f5ada0a06adf6a"
 dependencies = [
  "addr",
  "affinitypool",
  "ahash 0.8.12",
  "ammonia",
- "any_ascii",
+ "anyhow",
  "argon2",
  "async-channel",
- "async-executor",
  "async-graphql",
- "base64 0.21.7",
+ "async-stream",
+ "async-trait",
+ "base64",
  "bcrypt",
- "bincode",
  "blake3",
  "bytes",
- "castaway",
- "cedar-policy",
  "chrono",
  "ciborium",
  "dashmap",
  "deunicode",
  "dmp",
  "ext-sort",
+ "fastnum",
  "fst",
  "futures",
  "fuzzy-matcher",
- "geo",
+ "geo 0.32.0",
  "geo-types",
  "getrandom 0.3.4",
+ "headers",
  "hex",
  "http",
+ "humantime",
  "ipnet",
  "jsonwebtoken",
  "lexicmp",
- "linfa-linalg",
  "md-5",
- "nanoid",
+ "mime",
  "ndarray",
  "ndarray-stats",
  "num-traits",
  "num_cpus",
  "object_store",
  "parking_lot",
+ "path-clean",
  "pbkdf2",
- "pharos",
- "phf",
+ "phf 0.13.1",
  "pin-project-lite",
- "quick_cache 0.5.2",
+ "quick_cache",
  "radix_trie",
  "rand 0.8.5",
  "rayon",
  "reblessive",
  "regex",
  "reqwest",
- "revision 0.11.0",
+ "revision",
  "ring",
- "rmpv",
  "roaring",
  "rust-stemmers",
  "rust_decimal",
  "scrypt",
  "semver",
  "serde",
- "serde-content",
  "serde_json",
  "sha1",
  "sha2",
- "snap",
  "storekey",
  "strsim",
  "subtle",
+ "surrealdb-protocol",
+ "surrealdb-types",
  "surrealkv",
+ "surrealmx",
  "sysinfo",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
- "trice",
  "ulid",
  "unicase",
  "url",
  "uuid",
- "vart 0.8.1",
+ "vart",
  "wasm-bindgen-futures",
  "wasmtimer",
- "ws_stream_wasm",
+ "web-time",
+]
+
+[[package]]
+name = "surrealdb-protocol"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb37698e0493bcfac3229ecb6ec6894a3ad705a3a2087b1562eeb881b3db19d4"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "flatbuffers",
+ "futures",
+ "geo 0.28.0",
+ "prost",
+ "prost-types",
+ "rust_decimal",
+ "semver",
+ "serde",
+ "serde_json",
+ "tonic",
+ "tonic-prost",
+ "uuid",
+]
+
+[[package]]
+name = "surrealdb-types"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58db59440236ec593dbbb2487c4db11e4452ee636f9a1da3e3672c1cc1f42259"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "chrono",
+ "flatbuffers",
+ "geo 0.32.0",
+ "hex",
+ "http",
+ "papaya",
+ "rand 0.8.5",
+ "regex",
+ "rstest",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "surrealdb-protocol",
+ "surrealdb-types-derive",
+ "ulid",
+ "uuid",
+]
+
+[[package]]
+name = "surrealdb-types-derive"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617a808c9b3a2cd688c98027f4781c522507df73b42b1c56820ae72407eda016"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3812,21 +4400,52 @@ dependencies = [
 
 [[package]]
 name = "surrealkv"
-version = "0.9.3"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a5041979bdff8599a1d5f6cb7365acb9a79664e2a84e5c4fddac2b3969f7d1"
+checksum = "a6c1dd97851edc773c24afb282d6a17eb1bc798fafac53ea0d2951458854d472"
 dependencies = [
- "ahash 0.8.12",
+ "arc-swap",
+ "async-trait",
+ "byteorder",
  "bytes",
  "chrono",
  "crc32fast",
- "double-ended-peekable",
- "getrandom 0.2.17",
- "lru",
+ "crossbeam-skiplist",
+ "fs2",
+ "getrandom 0.3.4",
+ "guardian",
+ "integer-encoding",
+ "log",
+ "lz4_flex",
  "parking_lot",
- "quick_cache 0.6.18",
- "revision 0.10.0",
- "vart 0.9.3",
+ "quick_cache",
+ "rand 0.9.2",
+ "scopeguard",
+ "sha2",
+ "snap",
+ "tokio",
+]
+
+[[package]]
+name = "surrealmx"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6508449a7d1379a92a51ba49391b48ccab0b60dd11a4277c0dda965d8c99dbff"
+dependencies = [
+ "arc-swap",
+ "bincode",
+ "bytes",
+ "crossbeam-deque",
+ "crossbeam-queue",
+ "crossbeam-skiplist",
+ "lz4",
+ "papaya",
+ "parking_lot",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tracing",
+ "web-time",
 ]
 
 [[package]]
@@ -3873,15 +4492,15 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.33.1"
+version = "0.37.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
 dependencies = [
- "core-foundation-sys",
  "libc",
  "memchr",
  "ntapi",
- "rayon",
+ "objc2-core-foundation",
+ "objc2-io-kit",
  "windows",
 ]
 
@@ -3916,17 +4535,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3937,11 +4545,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -3957,9 +4565,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4004,15 +4612,6 @@ checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -4079,10 +4678,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tungstenite"
-version = "0.23.1"
+name = "tokio-stream"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -4092,6 +4702,25 @@ dependencies = [
  "tokio-rustls",
  "tungstenite",
  "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-tungstenite-wasm"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee909c02b8863f9bda87253127eb4da0e7e1342330b2583fbc4d1795c2f8"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "httparse",
+ "js-sys",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-tungstenite",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -4114,7 +4743,7 @@ version = "0.9.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
@@ -4138,7 +4767,7 @@ version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -4160,6 +4789,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
+name = "tonic"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4167,11 +4836,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4254,24 +4927,29 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.23.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.9.2",
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "url",
  "utf-8",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
@@ -4309,47 +4987,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
-name = "unicode-normalization"
-version = "0.1.25"
+name = "untrusted"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
-name = "unicode-script"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
-
-[[package]]
-name = "unicode-security"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e4ddba1535dd35ed8b61c52166b7155d7f4e4b8847cec6f48e71dc66d8b5e50"
-dependencies = [
- "unicode-normalization",
- "unicode-script",
-]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "url"
@@ -4401,12 +5054,6 @@ dependencies = [
 
 [[package]]
 name = "vart"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87782b74f898179396e93c0efabb38de0d58d50bbd47eae00c71b3a1144dbbae"
-
-[[package]]
-name = "vart"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1982d899e57d646498709735f16e9224cf1e8680676ad687f930cf8b5b555ae"
@@ -4416,6 +5063,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "walkdir"
@@ -4512,9 +5165,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -4525,9 +5178,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtimer"
-version = "0.2.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7ed9d8b15c7fb594d72bfb4b5a276f3d2029333cd93a932f376f5937f6f80ee"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
 dependencies = [
  "futures",
  "js-sys",
@@ -4562,10 +5215,19 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
 dependencies = [
- "phf",
+ "phf 0.11.3",
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4619,24 +5281,37 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.57.0"
+version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.6",
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.57.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -4645,22 +5320,22 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link",
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
- "windows-strings",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.57.0"
+name = "windows-future"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4668,17 +5343,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4698,17 +5362,33 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-result"
-version = "0.1.2"
+name = "windows-numerics"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4717,7 +5397,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4726,7 +5415,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -4734,15 +5432,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -4762,7 +5451,22 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -4787,7 +5491,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -4797,6 +5501,21 @@ dependencies = [
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -4812,6 +5531,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4821,6 +5546,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4848,6 +5579,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4857,6 +5594,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4872,6 +5615,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4881,6 +5630,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4914,25 +5669,6 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
-
-[[package]]
-name = "ws_stream_wasm"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c173014acad22e83f16403ee360115b38846fe754e735c5d9d3803fe70c6abc"
-dependencies = [
- "async_io_stream",
- "futures",
- "js-sys",
- "log",
- "pharos",
- "rustc_version",
- "send_wrapper",
- "thiserror 2.0.17",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,12 @@ license = "Apache License 2.0"
 crate-type = ["lib", "staticlib", "cdylib"]
 
 [dependencies]
-surrealdb = { git = "https://github.com/surrealdb/surrealdb.git", tag = "v2.4.1", features = [
+surrealdb = { version = "3.0.1", features = [
     "kv-surrealkv",
     "kv-mem",
-    "http",
+    "protocol-http",
 ] }
-surrealdb-core = { git = "https://github.com/surrealdb/surrealdb.git", tag = "v2.4.1", features = [
+surrealdb-core = { version = "3.0.1", features = [
     "http",
 ] }
 tokio = { version = "1.49.0", features = ["full"] }

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,12 @@ BUILD_DIR := build
 # Unix/Linux/macOS: Use default generator (usually Make or Ninja)
 GENERATOR_FLAG :=
 
-.PHONY: all configure build test clean
+.PHONY: all configure build test clean prereqs example-smoke verify
 
 all: build
+
+prereqs:
+	bash scripts/install-prereqs.sh
 
 configure:
 	cmake -S . -B $(BUILD_DIR) $(GENERATOR_FLAG)
@@ -22,6 +25,14 @@ ifeq ($(OS),Windows_NT)
 else
 	ctest --test-dir $(BUILD_DIR) --output-on-failure
 endif
+
+example-smoke: build
+	@echo "=== Building and running v3 smoke test ==="
+	$(BUILD_DIR)/v3_smoke_test
+
+verify: build test example-smoke
+	@echo ""
+	@echo "=== All verifications passed ==="
 
 clean:
 	cmake -E rm -rf $(BUILD_DIR)

--- a/c_test/examples/CMakeLists.txt
+++ b/c_test/examples/CMakeLists.txt
@@ -47,4 +47,24 @@ if(MSVC)
     target_link_options(saas_example PRIVATE /NODEFAULTLIB:MSVCRT)
 endif()
 
+# ============================================================================
+# V3 Smoke Test
+# ============================================================================
+
+add_executable(v3_smoke_test
+    v3_smoke_test.c
+)
+
+target_link_libraries(v3_smoke_test PRIVATE
+    surrealdb::surrealdb_c
+)
+
+set_target_properties(v3_smoke_test PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+)
+
+if(MSVC)
+    target_link_options(v3_smoke_test PRIVATE /NODEFAULTLIB:MSVCRT)
+endif()
+
 message(STATUS "Example binaries will be output to: ${_example_bin_dir}")

--- a/c_test/examples/v3_smoke_test.c
+++ b/c_test/examples/v3_smoke_test.c
@@ -1,0 +1,291 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "surrealdb.h"
+
+int main(void) {
+    sr_string_t err = NULL;
+    sr_surreal_t *db = NULL;
+    int failures = 0;
+
+    printf("=== SurrealDB v3 Smoke Test ===\n\n");
+
+    /* 1. Connect to in-memory database */
+    if (sr_connect(&err, &db, "mem://") < 0) {
+        printf("FAIL [connect]: %s\n", err);
+        sr_free_string(err);
+        return 1;
+    }
+    printf("OK   [connect mem://]\n");
+
+    /* 2. Select namespace and database */
+    if (sr_use_ns(db, &err, "test") < 0) {
+        printf("FAIL [use_ns]: %s\n", err);
+        sr_free_string(err);
+        failures++;
+    } else {
+        printf("OK   [use_ns test]\n");
+    }
+
+    if (sr_use_db(db, &err, "test") < 0) {
+        printf("FAIL [use_db]: %s\n", err);
+        sr_free_string(err);
+        failures++;
+    } else {
+        printf("OK   [use_db test]\n");
+    }
+
+    /* 3. Get version */
+    {
+        sr_string_t ver = NULL;
+        int rc = sr_version(db, &err, &ver);
+        if (rc < 0) {
+            printf("FAIL [version]: %s\n", err);
+            sr_free_string(err);
+            err = NULL;
+            failures++;
+        } else {
+            printf("OK   [version]: %s\n", ver);
+            sr_free_string(ver);
+        }
+    }
+
+    /* 4. Health check */
+    if (sr_health(db, &err) < 0) {
+        printf("FAIL [health]: %s\n", err);
+        sr_free_string(err);
+        err = NULL;
+        failures++;
+    } else {
+        printf("OK   [health]\n");
+    }
+
+    /* 5. Create a record */
+    {
+        sr_object_t content = sr_object_new();
+        sr_object_insert_str(&content, "name", "Alice");
+        sr_object_insert_int(&content, "age", 30);
+        sr_object_insert_str(&content, "email", "alice@example.com");
+
+        sr_object_t *result = NULL;
+        int rc = sr_create(db, &err, &result, "person:alice", &content);
+        if (rc < 0) {
+            printf("FAIL [create person:alice]: %s\n", err);
+            sr_free_string(err);
+            err = NULL;
+            failures++;
+        } else {
+            printf("OK   [create person:alice]\n");
+            if (result) sr_free_object(*result);
+        }
+        sr_free_object(content);
+    }
+
+    /* 6. Create another record */
+    {
+        sr_object_t content = sr_object_new();
+        sr_object_insert_str(&content, "name", "Bob");
+        sr_object_insert_int(&content, "age", 25);
+        sr_object_insert_str(&content, "email", "bob@example.com");
+
+        sr_object_t *result = NULL;
+        int rc = sr_create(db, &err, &result, "person:bob", &content);
+        if (rc < 0) {
+            printf("FAIL [create person:bob]: %s\n", err);
+            sr_free_string(err);
+            err = NULL;
+            failures++;
+        } else {
+            printf("OK   [create person:bob]\n");
+            if (result) sr_free_object(*result);
+        }
+        sr_free_object(content);
+    }
+
+    /* 7. Select all persons */
+    {
+        sr_value_t *persons = NULL;
+        int len = sr_select(db, &err, &persons, "person");
+        if (len < 0) {
+            printf("FAIL [select person]: %s\n", err);
+            sr_free_string(err);
+            err = NULL;
+            failures++;
+        } else {
+            printf("OK   [select person]: got %d records\n", len);
+            for (int i = 0; i < len; i++) {
+                sr_value_print(&persons[i]);
+            }
+            sr_free_arr(persons, len);
+        }
+    }
+
+    /* 8. Select a specific record */
+    {
+        sr_value_t *persons = NULL;
+        int len = sr_select(db, &err, &persons, "person:alice");
+        if (len < 0) {
+            printf("FAIL [select person:alice]: %s\n", err);
+            sr_free_string(err);
+            err = NULL;
+            failures++;
+        } else {
+            printf("OK   [select person:alice]: got %d records\n", len);
+            sr_free_arr(persons, len);
+        }
+    }
+
+    /* 9. Run a query */
+    {
+        sr_arr_res_t *results = NULL;
+        int num_stmts = sr_query(db, &err, &results, "SELECT * FROM person WHERE age > 20", NULL);
+        if (num_stmts < 0) {
+            printf("FAIL [query]: %s\n", err);
+            sr_free_string(err);
+            err = NULL;
+            failures++;
+        } else {
+            printf("OK   [query]: %d statement(s) returned\n", num_stmts);
+            for (int i = 0; i < num_stmts; i++) {
+                if (results[i].err.code == 0) {
+                    printf("  stmt %d: %d results\n", i, results[i].ok.len);
+                    for (int j = 0; j < results[i].ok.len; j++) {
+                        sr_value_print(&results[i].ok.arr[j]);
+                    }
+                } else {
+                    printf("  stmt %d: ERROR: %s\n", i, results[i].err.msg);
+                }
+            }
+            sr_free_arr_res_arr(results, num_stmts);
+        }
+    }
+
+    /* 10. Update a record with merge */
+    {
+        sr_object_t content = sr_object_new();
+        sr_object_insert_str(&content, "city", "New York");
+
+        sr_value_t *merged = NULL;
+        int len = sr_merge(db, &err, &merged, "person:alice", &content);
+        if (len < 0) {
+            printf("FAIL [merge person:alice]: %s\n", err);
+            sr_free_string(err);
+            err = NULL;
+            failures++;
+        } else {
+            printf("OK   [merge person:alice]: updated %d records\n", len);
+            sr_free_arr(merged, len);
+        }
+        sr_free_object(content);
+    }
+
+    /* 11. Delete a record */
+    {
+        sr_value_t *deleted = NULL;
+        int len = sr_delete(db, &err, &deleted, "person:bob");
+        if (len < 0) {
+            printf("FAIL [delete person:bob]: %s\n", err);
+            sr_free_string(err);
+            err = NULL;
+            failures++;
+        } else {
+            printf("OK   [delete person:bob]: deleted %d records\n", len);
+            sr_free_arr(deleted, len);
+        }
+    }
+
+    /* 12. Set and use a session variable */
+    {
+        sr_value_t *val = sr_value_string("test_value");
+        int rc = sr_set(db, &err, "my_var", val);
+        sr_value_free(val);
+        if (rc < 0) {
+            printf("FAIL [set variable]: %s\n", err);
+            sr_free_string(err);
+            err = NULL;
+            failures++;
+        } else {
+            printf("OK   [set variable]\n");
+        }
+    }
+
+    /* 13. Unset the variable */
+    {
+        int rc = sr_unset(db, &err, "my_var");
+        if (rc < 0) {
+            printf("FAIL [unset variable]: %s\n", err);
+            sr_free_string(err);
+            err = NULL;
+            failures++;
+        } else {
+            printf("OK   [unset variable]\n");
+        }
+    }
+
+    /* 14. Upsert a record */
+    {
+        sr_object_t content = sr_object_new();
+        sr_object_insert_str(&content, "name", "Charlie");
+        sr_object_insert_int(&content, "age", 35);
+
+        sr_value_t *upserted = NULL;
+        int len = sr_upsert(db, &err, &upserted, "person:charlie", &content);
+        if (len < 0) {
+            printf("FAIL [upsert person:charlie]: %s\n", err);
+            sr_free_string(err);
+            err = NULL;
+            failures++;
+        } else {
+            printf("OK   [upsert person:charlie]: %d records\n", len);
+            sr_free_arr(upserted, len);
+        }
+        sr_free_object(content);
+    }
+
+    /* 15. Create a relation */
+    {
+        sr_object_t content = sr_object_new();
+        sr_object_insert_str(&content, "since", "2024-01-01");
+
+        sr_value_t *result = NULL;
+        int len = sr_relate(db, &err, &result, "person:alice", "knows", "person:charlie", &content);
+        if (len < 0) {
+            printf("FAIL [relate]: %s\n", err);
+            sr_free_string(err);
+            err = NULL;
+            failures++;
+        } else {
+            printf("OK   [relate alice->knows->charlie]: %d records\n", len);
+            sr_free_arr(result, len);
+        }
+        sr_free_object(content);
+    }
+
+    /* 16. Final verification query with graph traversal */
+    {
+        sr_arr_res_t *results = NULL;
+        int num_stmts = sr_query(db, &err, &results,
+            "SELECT *, ->knows->person AS friends FROM person:alice", NULL);
+        if (num_stmts < 0) {
+            printf("FAIL [graph query]: %s\n", err);
+            sr_free_string(err);
+            err = NULL;
+            failures++;
+        } else {
+            printf("OK   [graph query]: %d statement(s)\n", num_stmts);
+            for (int i = 0; i < num_stmts; i++) {
+                if (results[i].err.code == 0) {
+                    for (int j = 0; j < results[i].ok.len; j++) {
+                        sr_value_print(&results[i].ok.arr[j]);
+                    }
+                }
+            }
+            sr_free_arr_res_arr(results, num_stmts);
+        }
+    }
+
+    sr_surreal_disconnect(db);
+
+    printf("\n=== Results: %d failure(s) ===\n", failures);
+    return failures > 0 ? 1 : 0;
+}

--- a/c_test/src/tests/memory_tests.c
+++ b/c_test/src/tests/memory_tests.c
@@ -27,14 +27,20 @@ TEST_TEAR_DOWN(Memory) {
 TEST(Memory, FreeArr) {
     TEST_ASSERT_NOT_NULL_MESSAGE(db, "Connection should succeed");
     
+    // In v3, selecting from a nonexistent table may error.
+    // Create the table first to ensure a clean result.
+    sr_arr_res_t *setup_results = NULL;
+    int setup_len = sr_query(db, &err, &setup_results, "DEFINE TABLE memory_test SCHEMALESS", NULL);
+    if (setup_len > 0) sr_free_arr_res_arr(setup_results, setup_len);
+    if (setup_len < 0 && err) { sr_free_string(err); err = NULL; }
+
     sr_value_t *results;
-    int len = sr_select(db, &err, &results, "nonexistent_table");
+    int len = sr_select(db, &err, &results, "memory_test");
     TEST_ASSERT_GREATER_OR_EQUAL_INT_MESSAGE(0, len, "select should succeed");
     
     if (len > 0) {
         sr_free_arr(results, len);
     }
-    // If we get here without crashing, test passes
 }
 
 TEST(Memory, FreeBytes) {

--- a/c_test/src/tests/query_tests.c
+++ b/c_test/src/tests/query_tests.c
@@ -45,6 +45,12 @@ TEST(Query, Query) {
 TEST(Query, SelectLive) {
     TEST_ASSERT_NOT_NULL_MESSAGE(db, "Connection should succeed");
     
+    // In v3, table must exist before live select. Create it first.
+    sr_arr_res_t *setup_results = NULL;
+    int setup_len = sr_query(db, &err, &setup_results, "DEFINE TABLE test_table SCHEMALESS", NULL);
+    if (setup_len > 0) sr_free_arr_res_arr(setup_results, setup_len);
+    if (setup_len < 0 && err) { sr_free_string(err); err = NULL; }
+
     sr_stream_t *stream;
     int result = sr_select_live(db, &err, &stream, "test_table");
     if (result < 0) {

--- a/c_test/src/tests/rpc_tests.c
+++ b/c_test/src/tests/rpc_tests.c
@@ -60,7 +60,7 @@ TEST(RPC, Execute) {
 
 TEST(RPC, Notifications) {
     sr_surreal_rpc_t *rpc;
-    sr_string_t err;
+    sr_string_t err = NULL;
     sr_option_t opts = {0};
     
     int result = sr_surreal_rpc_new(&err, &rpc, "memory", opts);
@@ -69,7 +69,6 @@ TEST(RPC, Notifications) {
         TEST_FAIL_MESSAGE("Failed to create RPC connection");
     }
     
-    // Get notifications stream
     sr_RpcStream *stream = NULL;
     result = sr_surreal_rpc_notifications(rpc, &err, &stream);
     if (result < 0) {
@@ -79,7 +78,6 @@ TEST(RPC, Notifications) {
     }
     TEST_ASSERT_NOT_NULL_MESSAGE(stream, "Notifications stream should not be NULL");
     
-    // Clean up
     sr_rpc_stream_free(stream);
     sr_surreal_rpc_free(rpc);
 }

--- a/include/surrealdb.h
+++ b/include/surrealdb.h
@@ -24,6 +24,7 @@ typedef enum sr_action {
   SR_ACTION_CREATE,
   SR_ACTION_UPDATE,
   SR_ACTION_DELETE,
+  SR_ACTION_KILLED,
   /**
    * Represents an action type added in a newer version of SurrealDB
    * that this C API version doesn't yet support

--- a/scripts/install-prereqs.sh
+++ b/scripts/install-prereqs.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+LOCAL_DIR="$PROJECT_DIR/.local"
+BIN_DIR="$LOCAL_DIR/bin"
+
+mkdir -p "$BIN_DIR"
+
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; }
+info() { printf '  \033[34m→\033[0m %s\n' "$1"; }
+warn() { printf '  \033[33m!\033[0m %s\n' "$1"; }
+
+command_available() {
+    command -v "$1" &>/dev/null || [[ -x "$BIN_DIR/$1" ]]
+}
+
+path_has_local() {
+    echo "$PATH" | tr ':' '\n' | grep -q "^$BIN_DIR$"
+}
+
+echo "=== surrealdb.c prerequisites installer ==="
+echo "    Install prefix: $LOCAL_DIR"
+echo ""
+
+# --- Rust toolchain ---
+if command -v rustc &>/dev/null && command -v cargo &>/dev/null; then
+    ok "Rust toolchain: $(rustc --version)"
+else
+    info "Installing Rust toolchain via rustup..."
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
+    export PATH="$HOME/.cargo/bin:$PATH"
+    ok "Rust installed: $(rustc --version)"
+fi
+
+# --- cmake ---
+if command_available cmake; then
+    ok "cmake: $(cmake --version 2>/dev/null | head -1)"
+else
+    info "Installing cmake..."
+    case "$OS" in
+        Darwin)
+            if command -v brew &>/dev/null; then
+                brew install cmake
+            else
+                warn "Homebrew not found. Please install cmake manually."
+                exit 1
+            fi
+            ;;
+        Linux)
+            CMAKE_VER="3.31.6"
+            case "$ARCH" in
+                x86_64)  CMAKE_ARCH="x86_64" ;;
+                aarch64) CMAKE_ARCH="aarch64" ;;
+                *)       warn "Unsupported arch $ARCH for cmake"; exit 1 ;;
+            esac
+            curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-${CMAKE_ARCH}.tar.gz" \
+                | tar xz -C "$LOCAL_DIR" --strip-components=1
+            ;;
+    esac
+    ok "cmake installed"
+fi
+
+# --- make ---
+if command_available make; then
+    ok "make: $(make --version 2>/dev/null | head -1)"
+else
+    info "Installing make..."
+    case "$OS" in
+        Darwin)
+            xcode-select --install 2>/dev/null || true
+            warn "Xcode Command Line Tools install triggered. Re-run this script after install completes."
+            exit 1
+            ;;
+        Linux)
+            if command -v apt-get &>/dev/null; then
+                sudo apt-get update && sudo apt-get install -y build-essential
+            elif command -v dnf &>/dev/null; then
+                sudo dnf install -y make gcc
+            else
+                warn "Cannot auto-install make. Please install it manually."
+                exit 1
+            fi
+            ;;
+    esac
+    ok "make installed"
+fi
+
+# --- C compiler ---
+if command -v cc &>/dev/null || command -v gcc &>/dev/null || command -v clang &>/dev/null; then
+    CC_BIN="$(command -v cc || command -v clang || command -v gcc)"
+    ok "C compiler: $CC_BIN"
+else
+    warn "No C compiler found. Install Xcode CLT (macOS) or build-essential (Linux)."
+    exit 1
+fi
+
+# --- SurrealDB CLI ---
+if command_available surreal; then
+    ok "surreal CLI: $(surreal version 2>/dev/null || echo 'available')"
+else
+    info "Installing SurrealDB CLI into $BIN_DIR..."
+    case "$OS" in
+        Darwin)
+            case "$ARCH" in
+                arm64)   SDB_ARCH="arm64" ;;
+                x86_64)  SDB_ARCH="x86_64" ;;
+                *)       warn "Unsupported arch $ARCH"; exit 1 ;;
+            esac
+            curl -fsSL "https://download.surrealdb.com/v3.0.1/surreal-v3.0.1.darwin-${SDB_ARCH}.tgz" \
+                | tar xz -C "$BIN_DIR"
+            ;;
+        Linux)
+            case "$ARCH" in
+                x86_64)  SDB_ARCH="x86_64" ;;
+                aarch64) SDB_ARCH="aarch64" ;;
+                *)       warn "Unsupported arch $ARCH"; exit 1 ;;
+            esac
+            curl -fsSL "https://download.surrealdb.com/v3.0.1/surreal-v3.0.1.linux-${SDB_ARCH}.tgz" \
+                | tar xz -C "$BIN_DIR"
+            ;;
+    esac
+    chmod +x "$BIN_DIR/surreal"
+    ok "surreal CLI installed to $BIN_DIR/surreal"
+fi
+
+echo ""
+echo "=== All prerequisites satisfied ==="
+echo ""
+if ! path_has_local; then
+    echo "Add this to your shell profile to use local tools:"
+    echo "  export PATH=\"$BIN_DIR:\$PATH\""
+    echo ""
+fi
+echo "Verify with:"
+echo "  rustc --version"
+echo "  cargo --version"
+echo "  cmake --version"
+echo "  make --version"
+echo "  $BIN_DIR/surreal version"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,22 @@ use surrealdb::{
     opt::Resource,
     opt::auth,
     opt::PatchOp,
-    sql, Surreal as sdbSurreal, Value as apiValue,
+    Surreal as sdbSurreal,
 };
+use surrealdb::types::{Value as sdbValue, Object as sdbObject, RecordId, RecordIdKey};
+
+fn parse_resource(s: &str) -> Resource {
+    if let Some((table, id)) = s.split_once(':') {
+        if !table.is_empty() && !id.is_empty() {
+            let record_id = RecordId {
+                table: table.to_string().into(),
+                key: RecordIdKey::String(id.to_string()),
+            };
+            return Resource::RecordId(record_id);
+        }
+    }
+    Resource::from(s)
+}
 use tokio::runtime::Runtime;
 use types::result::ArrayResult;
 
@@ -127,7 +141,7 @@ impl Surreal {
 
             let db = match rt.block_on(con_fut.into_future()) {
                 Ok(db) => db,
-                Err(e) => return Err(e.into()),
+                Err(e) => return Err(e.to_string().into()),
             };
 
             Ok(Surreal {
@@ -212,7 +226,7 @@ impl Surreal {
         check_null!(token, err_ptr, "token is null");
         with_surreal_async(db, err_ptr, |surreal| async {
             let token = unsafe { CStr::from_ptr(token) }.to_str()?;
-            surreal.db.authenticate(token).await?;
+            surreal.db.authenticate(token).await.map_err(|e| string_t::from(e.to_string()))?;
             Ok(0)
         })
     }
@@ -234,7 +248,7 @@ impl Surreal {
     #[export_name = "sr_begin"]
     pub extern "C" fn begin(db: &Surreal, err_ptr: *mut string_t) -> c_int {
         with_surreal_async(db, err_ptr, |surreal| async {
-            surreal.db.query("BEGIN TRANSACTION").await?;
+            surreal.db.query("BEGIN TRANSACTION").await.map_err(|e| string_t::from(e.to_string()))?;
             Ok(0)
         })
     }
@@ -256,7 +270,7 @@ impl Surreal {
     #[export_name = "sr_cancel"]
     pub extern "C" fn cancel(db: &Surreal, err_ptr: *mut string_t) -> c_int {
         with_surreal_async(db, err_ptr, |surreal| async {
-            surreal.db.query("CANCEL TRANSACTION").await?;
+            surreal.db.query("CANCEL TRANSACTION").await.map_err(|e| string_t::from(e.to_string()))?;
             Ok(0)
         })
     }
@@ -278,7 +292,7 @@ impl Surreal {
     #[export_name = "sr_commit"]
     pub extern "C" fn commit(db: &Surreal, err_ptr: *mut string_t) -> c_int {
         with_surreal_async(db, err_ptr, |surreal| async {
-            surreal.db.query("COMMIT TRANSACTION").await?;
+            surreal.db.query("COMMIT TRANSACTION").await.map_err(|e| string_t::from(e.to_string()))?;
             Ok(0)
         })
     }
@@ -308,16 +322,17 @@ impl Surreal {
         check_null!(content, err_ptr, "content is null");
         with_surreal_async(db, err_ptr, |surreal| async {
             let resource = unsafe { CStr::from_ptr(resource) }.to_str()?;
-            let content = sql::Object::from(unsafe { &*content }.clone());
+            let content = sdbObject::from(unsafe { &*content }.clone());
 
-            // Use raw query to properly handle both table names and record IDs
             let query = format!("CREATE {} CONTENT $content", resource);
-            let mut res = surreal.db.query(&query).bind(("content", content)).await?;
+            let mut res = surreal.db.query(&query).bind(("content", content)).await
+                .map_err(|e| string_t::from(e.to_string()))?;
             
-            let obj = match res.take::<apiValue>(0)?.into_inner() {
-                sql::Value::Array(arr) if !arr.is_empty() => {
+            let val: sdbValue = res.take(0).map_err(|e| string_t::from(e.to_string()))?;
+            let obj = match val {
+                sdbValue::Array(arr) if !arr.is_empty() => {
                     match arr.into_iter().next().unwrap() {
-                        sql::Value::Object(o) => o,
+                        sdbValue::Object(o) => o,
                         other => {
                             return Err(format!(
                                 "Expected object as return type of create, but found: {other:?}"
@@ -326,7 +341,7 @@ impl Surreal {
                         }
                     }
                 }
-                sql::Value::Object(o) => o,
+                sdbValue::Object(o) => o,
                 other => {
                     return Err(format!(
                         "Expected object as return type of create, but found: {other:?}"
@@ -335,7 +350,7 @@ impl Surreal {
                 }
             };
             if !res_ptr.is_null() {
-                let boxed = Box::new(obj.into());
+                let boxed = Box::new(Object::from(obj));
                 unsafe { res_ptr.write(Box::leak(boxed)) }
                 Ok(1)
             } else {
@@ -380,14 +395,15 @@ impl Surreal {
         with_surreal_async(db, err_ptr, |surreal| async {
             let resource = unsafe { CStr::from_ptr(resource) }.to_str()?;
 
-            let res = match surreal
+            let val: sdbValue = surreal
                 .db
-                .delete(Resource::from(resource))
-                .await?
-                .into_inner()
-            {
-                sql::Value::Array(a) => Array::from(a),
-                v => Array::from(vec![v.into()]),
+                .delete(parse_resource(resource))
+                .await
+                .map_err(|e| string_t::from(e.to_string()))?;
+
+            let res = match val {
+                sdbValue::Array(a) => Array::from(a),
+                v => Array::from(vec![Value::from(v)]),
             };
 
             let ArrayGen { ptr, len } = res.into();
@@ -426,7 +442,7 @@ impl Surreal {
         check_null!(file_path, err_ptr, "file_path is null");
         with_surreal_async(db, err_ptr, |surreal| async {
             let file_path = unsafe { CStr::from_ptr(file_path) }.to_str()?;
-            surreal.db.export(file_path).await?;
+            surreal.db.export(file_path).await.map_err(|e| string_t::from(e.to_string()))?;
             Ok(0)
         })
     }
@@ -448,7 +464,7 @@ impl Surreal {
     #[export_name = "sr_health"]
     pub extern "C" fn health(db: &Surreal, err_ptr: *mut string_t) -> c_int {
         with_surreal_async(db, err_ptr, |surreal| async {
-            surreal.db.health().await?;
+            surreal.db.health().await.map_err(|e| string_t::from(e.to_string()))?;
             Ok(0)
         })
     }
@@ -482,7 +498,7 @@ impl Surreal {
         check_null!(file_path, err_ptr, "file_path is null");
         with_surreal_async(db, err_ptr, |surreal| async {
             let file_path = unsafe { CStr::from_ptr(file_path) }.to_str()?;
-            surreal.db.import(file_path).await?;
+            surreal.db.import(file_path).await.map_err(|e| string_t::from(e.to_string()))?;
             Ok(0)
         })
     }
@@ -526,17 +542,18 @@ impl Surreal {
         check_null!(content, err_ptr, "content is null");
         with_surreal_async(db, err_ptr, |surreal| async {
             let resource = unsafe { CStr::from_ptr(resource) }.to_str()?;
-            let content = sql::Object::from(unsafe { &*content }.clone());
+            let content = sdbObject::from(unsafe { &*content }.clone());
 
-            let res = match surreal
+            let val: sdbValue = surreal
                 .db
-                .insert(Resource::from(resource))
+                .insert(parse_resource(resource))
                 .content(content)
-                .await?
-                .into_inner()
-            {
-                sql::Value::Array(a) => Array::from(a),
-                v => Array::from(vec![v.into()]),
+                .await
+                .map_err(|e| string_t::from(e.to_string()))?;
+
+            let res = match val {
+                sdbValue::Array(a) => Array::from(a),
+                v => Array::from(vec![Value::from(v)]),
             };
 
             let ArrayGen { ptr, len } = res.into();
@@ -591,17 +608,18 @@ impl Surreal {
         check_null!(content, err_ptr, "content is null");
         with_surreal_async(db, err_ptr, |surreal| async {
             let table = unsafe { CStr::from_ptr(table) }.to_str()?;
-            let content = sql::Object::from(unsafe { &*content }.clone());
+            let content = sdbObject::from(unsafe { &*content }.clone());
 
-            let res = surreal
+            let val: sdbValue = surreal
                 .db
                 .insert(Resource::from(table))
                 .relation(content)
-                .await?;
+                .await
+                .map_err(|e| string_t::from(e.to_string()))?;
 
-            let result = match res.into_inner() {
-                sql::Value::Array(a) => Array::from(a),
-                v => Array::from(vec![v.into()]),
+            let result = match val {
+                sdbValue::Array(a) => Array::from(a),
+                v => Array::from(vec![Value::from(v)]),
             };
 
             let ArrayGen { ptr, len } = result.into();
@@ -649,22 +667,23 @@ impl Surreal {
         with_surreal_async(db, err_ptr, |surreal| async {
             let function_name = unsafe { CStr::from_ptr(function_name) }.to_str()?;
             
-            let args_vec: Vec<sql::Value> = if args.is_null() {
+            let args_vec: Vec<sdbValue> = if args.is_null() {
                 vec![]
             } else {
                 let arr = unsafe { &*args };
-                arr.as_slice().iter().cloned().map(|v| v.into()).collect()
+                arr.as_slice().iter().cloned().map(|v| sdbValue::from(v)).collect()
             };
 
-            let res: apiValue = surreal
+            let res: sdbValue = surreal
                 .db
                 .run(function_name)
                 .args(args_vec)
-                .await?;
+                .await
+                .map_err(|e| string_t::from(e.to_string()))?;
 
-            let result_arr = match res.into_inner() {
-                sql::Value::Array(a) => Array::from(a),
-                v => Array::from(vec![v.into()]),
+            let result_arr = match res {
+                sdbValue::Array(a) => Array::from(a),
+                v => Array::from(vec![Value::from(v)]),
             };
 
             let ArrayGen { ptr, len } = result_arr.into();
@@ -730,15 +749,16 @@ impl Surreal {
             let mut q = surreal.db.query(&query);
             
             if !content.is_null() {
-                let content_obj = sql::Object::from(unsafe { &*content }.clone());
+                let content_obj = sdbObject::from(unsafe { &*content }.clone());
                 q = q.bind(("content", content_obj));
             }
 
-            let mut res = q.await?;
+            let mut res = q.await.map_err(|e| string_t::from(e.to_string()))?;
             
-            let result = match res.take::<apiValue>(0)?.into_inner() {
-                sql::Value::Array(a) => Array::from(a),
-                v => Array::from(vec![v.into()]),
+            let val: sdbValue = res.take(0).map_err(|e| string_t::from(e.to_string()))?;
+            let result = match val {
+                sdbValue::Array(a) => Array::from(a),
+                v => Array::from(vec![Value::from(v)]),
             };
 
             let ArrayGen { ptr, len } = result.into();
@@ -765,7 +785,7 @@ impl Surreal {
     #[export_name = "sr_invalidate"]
     pub extern "C" fn invalidate(db: &Surreal, err_ptr: *mut string_t) -> c_int {
         with_surreal_async(db, err_ptr, |surreal| async {
-            surreal.db.invalidate().await?;
+            surreal.db.invalidate().await.map_err(|e| string_t::from(e.to_string()))?;
             Ok(0)
         })
     }
@@ -797,7 +817,7 @@ impl Surreal {
         with_surreal_async(db, err_ptr, |surreal| async {
             let uuid_str = unsafe { CStr::from_ptr(query_id) }.to_str()?;
             let query = format!("KILL u'{}'", uuid_str);
-            surreal.db.query(query).await?;
+            surreal.db.query(query).await.map_err(|e| string_t::from(e.to_string()))?;
             Ok(0)
         })
     }
@@ -839,18 +859,18 @@ impl Surreal {
     ) -> c_int {
         check_null!(stream_ptr, err_ptr, "stream_ptr is null");
         check_null!(resource, err_ptr, "resource is null");
-        use surrealdb::method::Stream as sdbStream;
+        use surrealdb::method::Stream as sdbStreamType;
         with_surreal_async(db, err_ptr, |surreal| async {
             let resource = unsafe { CStr::from_ptr(resource) }.to_str()?;
 
-            let stream_inner: sdbStream<apiValue> =
-                surreal.db.select(Resource::from(resource)).live().await?;
+            let stream_inner: sdbStreamType<sdbValue> =
+                surreal.db.select(parse_resource(resource)).live().await
+                    .map_err(|e| string_t::from(e.to_string()))?;
 
             let stream_boxed = Box::new(Stream::new(stream_inner, surreal.rt.handle().clone()));
 
             unsafe { stream_ptr.write(Box::leak(stream_boxed)) };
 
-            // return 1 because 1 stream was written to *stream_ptr
             Ok(1)
         })
     }
@@ -894,17 +914,18 @@ impl Surreal {
         check_null!(content, err_ptr, "content is null");
         with_surreal_async(db, err_ptr, |surreal| async {
             let resource = unsafe { CStr::from_ptr(resource) }.to_str()?;
-            let content = sql::Object::from(unsafe { &*content }.clone());
+            let content = sdbObject::from(unsafe { &*content }.clone());
 
-            let res = match surreal
+            let val: sdbValue = surreal
                 .db
-                .update(Resource::from(resource))
+                .update(parse_resource(resource))
                 .merge(content)
-                .await?
-                .into_inner()
-            {
-                sql::Value::Array(a) => Array::from(a),
-                v => Array::from(vec![v.into()]),
+                .await
+                .map_err(|e| string_t::from(e.to_string()))?;
+
+            let res = match val {
+                sdbValue::Array(a) => Array::from(a),
+                v => Array::from(vec![Value::from(v)]),
             };
 
             let ArrayGen { ptr, len } = res.into();
@@ -957,17 +978,18 @@ impl Surreal {
         with_surreal_async(db, err_ptr, |surreal| async {
             let resource = unsafe { CStr::from_ptr(resource) }.to_str()?;
             let path = unsafe { CStr::from_ptr(path) }.to_str()?;
-            let value: sql::Value = unsafe { &*value }.clone().into();
+            let value: sdbValue = unsafe { &*value }.clone().into();
 
-            let res = surreal
+            let val: sdbValue = surreal
                 .db
-                .update(Resource::from(resource))
+                .update(parse_resource(resource))
                 .patch(PatchOp::add(path, value))
-                .await?;
+                .await
+                .map_err(|e| string_t::from(e.to_string()))?;
 
-            let result = match res.into_inner() {
-                sql::Value::Array(a) => Array::from(a),
-                v => Array::from(vec![v.into()]),
+            let result = match val {
+                sdbValue::Array(a) => Array::from(a),
+                v => Array::from(vec![Value::from(v)]),
             };
 
             let ArrayGen { ptr, len } = result.into();
@@ -1015,15 +1037,16 @@ impl Surreal {
             let resource = unsafe { CStr::from_ptr(resource) }.to_str()?;
             let path = unsafe { CStr::from_ptr(path) }.to_str()?;
 
-            let res = surreal
+            let val: sdbValue = surreal
                 .db
-                .update(Resource::from(resource))
+                .update(parse_resource(resource))
                 .patch(PatchOp::remove(path))
-                .await?;
+                .await
+                .map_err(|e| string_t::from(e.to_string()))?;
 
-            let result = match res.into_inner() {
-                sql::Value::Array(a) => Array::from(a),
-                v => Array::from(vec![v.into()]),
+            let result = match val {
+                sdbValue::Array(a) => Array::from(a),
+                v => Array::from(vec![Value::from(v)]),
             };
 
             let ArrayGen { ptr, len } = result.into();
@@ -1074,17 +1097,18 @@ impl Surreal {
         with_surreal_async(db, err_ptr, |surreal| async {
             let resource = unsafe { CStr::from_ptr(resource) }.to_str()?;
             let path = unsafe { CStr::from_ptr(path) }.to_str()?;
-            let value: sql::Value = unsafe { &*value }.clone().into();
+            let value: sdbValue = unsafe { &*value }.clone().into();
 
-            let res = surreal
+            let val: sdbValue = surreal
                 .db
-                .update(Resource::from(resource))
+                .update(parse_resource(resource))
                 .patch(PatchOp::replace(path, value))
-                .await?;
+                .await
+                .map_err(|e| string_t::from(e.to_string()))?;
 
-            let result = match res.into_inner() {
-                sql::Value::Array(a) => Array::from(a),
-                v => Array::from(vec![v.into()]),
+            let result = match val {
+                sdbValue::Array(a) => Array::from(a),
+                v => Array::from(vec![Value::from(v)]),
             };
 
             let ArrayGen { ptr, len } = result.into();
@@ -1115,24 +1139,25 @@ impl Surreal {
         check_null!(query, err_ptr, "query is null");
         with_surreal_async(db, err_ptr, |surreal| async {
             let query = unsafe { CStr::from_ptr(query) }.to_str()?;
-            let vars: sql::Object = match vars.is_null() {
-                true => Default::default(),
+            let vars: sdbObject = match vars.is_null() {
+                true => sdbObject::default(),
                 false => unsafe { &*vars }.clone().into(),
             };
 
-            let mut res = surreal.db.query(query).bind(vars).await?;
+            let mut res = surreal.db.query(query).bind(vars).await
+                .map_err(|e| string_t::from(e.to_string()))?;
             let res_len = res.num_statements();
 
             let mut acc = Vec::with_capacity(res_len);
             for index in 0..res_len {
-                let api_res = res.take::<apiValue>(index);
-                let arr_res = match api_res.map(|v| v.into_inner()) {
-                    Ok(sql::Value::Array(arr)) => {
+                let api_res: Result<sdbValue, _> = res.take(index);
+                let arr_res = match api_res {
+                    Ok(sdbValue::Array(arr)) => {
                         let a = arr.into();
                         ArrayResult::ok(a)
                     }
                     Ok(val) => {
-                        let arr: Array = vec![val.into()].into();
+                        let arr: Array = vec![Value::from(val)].into();
                         ArrayResult::ok(arr)
                     }
                     Err(e) => ArrayResult::err(e.to_string()),
@@ -1191,14 +1216,15 @@ impl Surreal {
         with_surreal_async(db, err_ptr, |surreal| async {
             let resource = unsafe { CStr::from_ptr(resource) }.to_str()?;
 
-            let res = match surreal
+            let val: sdbValue = surreal
                 .db
-                .select(Resource::from(resource))
-                .await?
-                .into_inner()
-            {
-                sql::Value::Array(a) => Array::from(a),
-                v => Array::from(vec![v.into()]),
+                .select(parse_resource(resource))
+                .await
+                .map_err(|e| string_t::from(e.to_string()))?;
+
+            let res = match val {
+                sdbValue::Array(a) => Array::from(a),
+                v => Array::from(vec![Value::from(v)]),
             };
 
             let ArrayGen { ptr, len } = res.into();
@@ -1207,6 +1233,7 @@ impl Surreal {
             Ok(len as c_int)
         })
     }
+
     /// Set a variable for the current session
     ///
     /// Defines a session variable that can be referenced in queries.
@@ -1240,9 +1267,9 @@ impl Surreal {
         check_null!(value, err_ptr, "value is null");
         with_surreal_async(db, err_ptr, |surreal| async {
             let key = unsafe { CStr::from_ptr(key) }.to_str()?;
-            let value: sql::Value = unsafe { &*value }.clone().into();
+            let value: sdbValue = unsafe { &*value }.clone().into();
             
-            surreal.db.set(key, value).await?;
+            surreal.db.set(key, value).await.map_err(|e| string_t::from(e.to_string()))?;
             Ok(0)
         })
     }
@@ -1359,78 +1386,76 @@ impl Surreal {
             let token: String = match scope {
                 credentials_scope::ROOT => {
                     let login = auth::Root {
-                        username: user,
-                        password: pass,
+                        username: user.to_string(),
+                        password: pass.to_string(),
                     };
-                    let jwt = surreal.db.signin(login).await?;
-                    jwt.into_insecure_token()
+                    let jwt = surreal.db.signin(login).await.map_err(|e| string_t::from(e.to_string()))?;
+                    jwt.access.into_insecure_token()
                 }
                 credentials_scope::NAMESPACE => {
                     if ns.is_empty() {
-                        Err("Namespace must be provided.")?
+                        return Err("Namespace must be provided.".into());
                     }
 
                     let login = auth::Namespace {
-                        namespace: ns,
-                        username: user,
-                        password: pass,
+                        namespace: ns.to_string(),
+                        username: user.to_string(),
+                        password: pass.to_string(),
                     };
 
-                    let jwt = surreal.db.signin(login).await?;
-                    jwt.into_insecure_token()
+                    let jwt = surreal.db.signin(login).await.map_err(|e| string_t::from(e.to_string()))?;
+                    jwt.access.into_insecure_token()
                 }
                 credentials_scope::DATABASE => {
                     if ns.is_empty() {
-                        Err("Namespace must be provided.")?
+                        return Err("Namespace must be provided.".into());
                     }
                     if db_name.is_empty() {
-                        Err("Database must be provided.")?
+                        return Err("Database must be provided.".into());
                     }
 
                     let login = auth::Database {
-                        namespace: ns,
-                        database: db_name,
-                        username: user,
-                        password: pass,
+                        namespace: ns.to_string(),
+                        database: db_name.to_string(),
+                        username: user.to_string(),
+                        password: pass.to_string(),
                     };
 
-                    let jwt = surreal.db.signin(login).await?;
-                    jwt.into_insecure_token()
+                    let jwt = surreal.db.signin(login).await.map_err(|e| string_t::from(e.to_string()))?;
+                    jwt.access.into_insecure_token()
                 }
                 credentials_scope::RECORD => {
                     if ns.is_empty() {
-                        Err("Namespace must be provided.")?
+                        return Err("Namespace must be provided.".into());
                     }
                     if db_name.is_empty() {
-                        Err("Database must be provided.")?
+                        return Err("Database must be provided.".into());
                     }
                     if ac.is_empty() {
-                        Err("Access method must be provided.")?
+                        return Err("Access method must be provided.".into());
                     }
 
-                    // Use custom params if provided, otherwise use username/password from creds
-                    let record_params: sql::Object = if !params.is_null() {
+                    let record_params: sdbObject = if !params.is_null() {
                         unsafe { &*params }.clone().into()
                     } else {
-                        let mut obj = sql::Object::default();
-                        obj.insert("username".to_string(), sql::Value::from(user));
-                        obj.insert("password".to_string(), sql::Value::from(pass));
+                        let mut obj = sdbObject::default();
+                        obj.insert("username".to_string(), sdbValue::String(user.to_string()));
+                        obj.insert("password".to_string(), sdbValue::String(pass.to_string()));
                         obj
                     };
 
                     let login = auth::Record {
-                        namespace: ns,
-                        database: db_name,
-                        access: ac,
+                        namespace: ns.to_string(),
+                        database: db_name.to_string(),
+                        access: ac.to_string(),
                         params: record_params,
                     };
 
-                    let jwt = surreal.db.signin(login).await?;
-                    jwt.into_insecure_token()
+                    let jwt = surreal.db.signin(login).await.map_err(|e| string_t::from(e.to_string()))?;
+                    jwt.access.into_insecure_token()
                 }
             };
             
-            // Return token if pointer provided
             if !token_ptr.is_null() {
                 unsafe { *token_ptr = token.to_string_t(); }
             }
@@ -1438,8 +1463,6 @@ impl Surreal {
             Ok(0)
         })
     }
-
-
 
     /// Sign up a new user with credentials
     ///
@@ -1531,48 +1554,46 @@ impl Surreal {
 
             let token: String = match scope {
                 credentials_scope::ROOT => {
-                    Err("Cannot signup as ROOT user")?
+                    return Err("Cannot signup as ROOT user".into());
                 }
                 credentials_scope::NAMESPACE => {
-                    Err("Namespace scope does not support signup. Use RECORD scope instead.")?
+                    return Err("Namespace scope does not support signup. Use RECORD scope instead.".into());
                 }
                 credentials_scope::DATABASE => {
-                    Err("Database scope does not support signup. Use RECORD scope instead.")?
+                    return Err("Database scope does not support signup. Use RECORD scope instead.".into());
                 }
                 credentials_scope::RECORD => {
                     if ns.is_empty() {
-                        Err("Namespace must be provided.")?
+                        return Err("Namespace must be provided.".into());
                     }
                     if db_name.is_empty() {
-                        Err("Database must be provided.")?
+                        return Err("Database must be provided.".into());
                     }
                     if ac.is_empty() {
-                        Err("Access method must be provided.")?
+                        return Err("Access method must be provided.".into());
                     }
 
-                    // Use custom params if provided, otherwise use username/password from creds
-                    let record_params: sql::Object = if !params.is_null() {
+                    let record_params: sdbObject = if !params.is_null() {
                         unsafe { &*params }.clone().into()
                     } else {
-                        let mut obj = sql::Object::default();
-                        obj.insert("username".to_string(), sql::Value::from(user));
-                        obj.insert("password".to_string(), sql::Value::from(pass));
+                        let mut obj = sdbObject::default();
+                        obj.insert("username".to_string(), sdbValue::String(user.to_string()));
+                        obj.insert("password".to_string(), sdbValue::String(pass.to_string()));
                         obj
                     };
 
                     let signup = auth::Record {
-                        namespace: ns,
-                        database: db_name,
-                        access: ac,
+                        namespace: ns.to_string(),
+                        database: db_name.to_string(),
+                        access: ac.to_string(),
                         params: record_params,
                     };
 
-                    let jwt = surreal.db.signup(signup).await?;
-                    jwt.into_insecure_token()
+                    let jwt = surreal.db.signup(signup).await.map_err(|e| string_t::from(e.to_string()))?;
+                    jwt.access.into_insecure_token()
                 }
             };
             
-            // Return token if pointer provided
             if !token_ptr.is_null() {
                 unsafe { *token_ptr = token.to_string_t(); }
             }
@@ -1610,7 +1631,7 @@ impl Surreal {
         check_null!(key, err_ptr, "key is null");
         with_surreal_async(db, err_ptr, |surreal| async {
             let key = unsafe { CStr::from_ptr(key) }.to_str()?;
-            surreal.db.unset(key).await?;
+            surreal.db.unset(key).await.map_err(|e| string_t::from(e.to_string()))?;
             Ok(0)
         })
     }
@@ -1654,17 +1675,18 @@ impl Surreal {
         check_null!(content, err_ptr, "content is null");
         with_surreal_async(db, err_ptr, |surreal| async {
             let resource = unsafe { CStr::from_ptr(resource) }.to_str()?;
-            let content = sql::Object::from(unsafe { &*content }.clone());
+            let content = sdbObject::from(unsafe { &*content }.clone());
 
-            let res = match surreal
+            let val: sdbValue = surreal
                 .db
-                .update(Resource::from(resource))
+                .update(parse_resource(resource))
                 .content(content)
-                .await?
-                .into_inner()
-            {
-                sql::Value::Array(a) => Array::from(a),
-                v => Array::from(vec![v.into()]),
+                .await
+                .map_err(|e| string_t::from(e.to_string()))?;
+
+            let res = match val {
+                sdbValue::Array(a) => Array::from(a),
+                v => Array::from(vec![Value::from(v)]),
             };
 
             let ArrayGen { ptr, len } = res.into();
@@ -1713,17 +1735,18 @@ impl Surreal {
         check_null!(content, err_ptr, "content is null");
         with_surreal_async(db, err_ptr, |surreal| async {
             let resource = unsafe { CStr::from_ptr(resource) }.to_str()?;
-            let content = sql::Object::from(unsafe { &*content }.clone());
+            let content = sdbObject::from(unsafe { &*content }.clone());
 
-            let res = match surreal
+            let val: sdbValue = surreal
                 .db
-                .upsert(Resource::from(resource))
+                .upsert(parse_resource(resource))
                 .content(content)
-                .await?
-                .into_inner()
-            {
-                sql::Value::Array(a) => Array::from(a),
-                v => Array::from(vec![v.into()]),
+                .await
+                .map_err(|e| string_t::from(e.to_string()))?;
+
+            let res = match val {
+                sdbValue::Array(a) => Array::from(a),
+                v => Array::from(vec![Value::from(v)]),
             };
 
             let ArrayGen { ptr, len } = res.into();
@@ -1760,7 +1783,7 @@ impl Surreal {
         with_surreal_async(db, err_ptr, |surreal| async {
             let db_name = unsafe { CStr::from_ptr(db_name) }.to_str()?;
 
-            surreal.db.use_db(db_name).await?;
+            surreal.db.use_db(db_name).await.map_err(|e| string_t::from(e.to_string()))?;
 
             Ok(0)
         })
@@ -1793,7 +1816,7 @@ impl Surreal {
         with_surreal_async(db, err_ptr, |surreal| async {
             let ns_name = unsafe { CStr::from_ptr(ns_name) }.to_str()?;
 
-            surreal.db.use_ns(ns_name).await?;
+            surreal.db.use_ns(ns_name).await.map_err(|e| string_t::from(e.to_string()))?;
 
             Ok(0)
         })
@@ -1832,7 +1855,7 @@ impl Surreal {
     ) -> c_int {
         check_null!(res_ptr, err_ptr, "res_ptr is null");
         with_surreal_async(db, err_ptr, |surreal| async {
-            let res = surreal.db.version().await?;
+            let res = surreal.db.version().await.map_err(|e| string_t::from(e.to_string()))?;
             let res_string = res.to_string();
             let len = res_string.bytes().len();
             let res_str: string_t = res_string.to_string_t();
@@ -1843,36 +1866,6 @@ impl Surreal {
         })
     }
 }
-
-// fn with_surreal<C>(db: &Surreal, err_ptr: *mut string_t, fun: C) -> c_int
-// where
-//     C: FnOnce(&Surreal) -> Result<c_int, string_t>,
-// {
-//     if db.ps.load(Ordering::Acquire) {
-//         std::process::abort()
-//     }
-
-//     let res = match catch_unwind(AssertUnwindSafe(|| fun(&db))) {
-//         Ok(r) => r,
-//         Err(e) => {
-//             if let Some(e_str) = e.downcast_ref::<&str>() {
-//                 let e_string: string_t = format!("Panicked with: {e_str}").into();
-//                 unsafe { err_ptr.write(e_string) }
-//             } else {
-//                 unsafe { err_ptr.write("Panicked".into()) }
-//             }
-//             return SR_FATAL;
-//         }
-//     };
-
-//     match res {
-//         Ok(n) => n,
-//         Err(e) => {
-//             unsafe { err_ptr.write(e) }
-//             SR_ERROR
-//         }
-//     }
-// }
 
 /// Execute a given closure in an async context, which returns a result then catches panics and writes errors appropriately
 fn with_surreal_async<'a, 'b, C, F>(db: &'a Surreal, err_ptr: *mut string_t, fun: C) -> c_int

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::BTreeMap,
     ffi::{c_char, c_int, CStr},
     future::IntoFuture,
     panic::{catch_unwind, AssertUnwindSafe},
@@ -8,32 +7,26 @@ use std::{
     time::Duration,
 };
 use std::sync::Arc;
-use arc_swap::ArcSwap;
-use surrealdb::dbs::Session;
-use surrealdb::kvs::Datastore;
-use surrealdb::rpc::format::cbor;
-use surrealdb::rpc::Method;
-use surrealdb::rpc::RpcContext;
-use surrealdb::rpc::Data;
-use surrealdb::sql;
-use surrealdb_core::rpc::{RpcProtocolV1, RpcProtocolV2};
+use surrealdb_core::dbs::Session;
+use surrealdb_core::kvs::Datastore;
+use surrealdb_core::rpc::{Method, RpcProtocol, DbResult};
+use surrealdb::types::{Value as sdbValue, HashMap};
 use tokio::{runtime::Runtime, sync::RwLock};
-use tokio::sync::Semaphore;
+
 use crate::{array::MakeArray, opts::Options, stream::RpcStream, string::string_t, SR_ERROR, SR_FATAL};
 
-/// The object representing a Surreal connection
+/// The object representing a Surreal RPC connection
 ///
 /// It is safe to be referenced from multiple threads
 /// If any operation, on any thread returns SR_FATAL then the connection is poisoned and must not be used again.
 /// (use will cause the program to abort)
 ///
-/// should be freed with sr_surreal_disconnect
+/// should be freed with sr_surreal_rpc_free
 pub struct SurrealRpc {
     inner: RwLock<SurrealRpcInner>,
     rt: Runtime,
     ps: AtomicBool,
 }
-
 /// create new rpc context
 ///
 /// # Examples
@@ -66,12 +59,11 @@ impl SurrealRpc {
 
             let mut kvs = match rt.block_on(con_fut.into_future()) {
                 Ok(db) => db,
-                Err(e) => return Err(e.into()),
+                Err(e) => return Err(e.to_string().into()),
             };
 
             kvs = kvs.with_notifications();
 
-            kvs = kvs.with_strict_mode(options.strict);
             if options.query_timeout != 0 {
                 kvs =
                     kvs.with_query_timeout(Some(Duration::from_secs(options.query_timeout as u64)))
@@ -82,11 +74,13 @@ impl SurrealRpc {
                 )))
             }
 
+            let session_map = HashMap::default();
+            let default_session = Arc::new(RwLock::new(Session::default().with_rt(true)));
+            session_map.insert(None, default_session);
+
             let inner = SurrealRpcInner {
                 kvs,
-                sess: ArcSwap::new(Arc::new(Session::default().with_rt(true))),
-                vars: BTreeMap::default(),
-                lock: Arc::new(Semaphore::new(1)),
+                session_map,
             };
 
             Ok(SurrealRpc {
@@ -122,7 +116,7 @@ impl SurrealRpc {
         }
     }
 
-    /// Execute an RPC request
+    /// Execute an RPC request via raw CBOR bytes
     ///
     /// # Safety
     ///
@@ -155,48 +149,36 @@ impl SurrealRpc {
         with_async(self, err_ptr, |ctx| async {
             let in_bytes = slice_from_raw_parts(ptr, len as usize);
             let in_bytes = unsafe { &*in_bytes };
-            let in_data = cbor::req(in_bytes.to_vec())?;
-            let method = Method::parse_case_insensitive(in_data.method.to_str());
-            //let method = Method::parse(in_data.method);
-            /*
-            let res = match method.can_be_immut() {
-                true => {
-                    ctx.inner
-                        .read()
-                        .await
-                        .execute_immut(method, in_data.params)
-                        .await
-                }
-                false => {
-                    ctx.inner
-                        .write()
-                        .await
-                        .execute(None, method, in_data.params)
-                        .await?
-                }
-            }?;
-             */
-            let inner = &ctx.inner.write().await;
-            let res = <SurrealRpcInner as RpcProtocolV2>::execute(
+
+            let in_value: ciborium::Value = ciborium::from_reader(in_bytes.as_ref())
+                .map_err(|e| string_t::from(format!("CBOR decode error: {e}")))?;
+
+            let (method_str, params) = parse_cbor_request(&in_value)?;
+            let method = Method::parse_case_insensitive(&method_str);
+
+            let inner = &ctx.inner.read().await;
+            let res = <SurrealRpcInner as RpcProtocol>::execute(
                 &*inner,
+                None,
+                None,
                 method,
-                in_data.params,
-            ).await?;
+                params,
+            ).await.map_err(|e| string_t::from(e.to_string()))?;
             
-            // Currently only Data::Other is supported; Data::Live requires stream handling
-            let result = match res {
-                Data::Other(v) => {
-                    let out = cbor::res(v)?.make_array();
-                    //let out = cbor::res(res)?.make_array();
+            match res {
+                DbResult::Other(v) => {
+                    let cbor_val = value_to_cbor(&v);
+                    let mut out_bytes = Vec::new();
+                    ciborium::into_writer(&cbor_val, &mut out_bytes)
+                        .map_err(|e| string_t::from(format!("CBOR encode error: {e}")))?;
+                    let out = out_bytes.make_array();
                     unsafe { res_ptr.write(out.ptr) }
                     Ok(out.len)
                 }
                 _ => {
-                    Err("C SDK: RPC::execute had unimplemented response.")
+                    Err(string_t::from("C SDK: RPC::execute had unimplemented response."))
                 }
-            }?;
-            
-            Ok(result)
+            }
         })
     }
 
@@ -227,7 +209,7 @@ impl SurrealRpc {
                 .await
                 .kvs
                 .notifications()
-                .ok_or("Notifications not enabled")?;
+                .ok_or(string_t::from("Notifications not enabled"))?;
 
             let rpc_stream = RpcStream::new(receiver);
             let stream_boxed = Box::new(rpc_stream);
@@ -238,10 +220,6 @@ impl SurrealRpc {
     }
 
     /// Free an RPC context
-    ///
-    /// # Safety
-    ///
-    /// - `ctx` must be a valid pointer to a SurrealRpc, or null (no-op)
     #[export_name = "sr_surreal_rpc_free"]
     pub extern "C" fn rpc_free(ctx: *mut SurrealRpc) {
         if ctx.is_null() {
@@ -249,6 +227,85 @@ impl SurrealRpc {
         }
         let boxed = unsafe { Box::from_raw(ctx) };
         drop(boxed)
+    }
+}
+
+fn parse_cbor_request(value: &ciborium::Value) -> Result<(String, surrealdb::types::Array), string_t> {
+    let map = value.as_map().ok_or(string_t::from("Expected CBOR map for RPC request"))?;
+    
+    let mut method = String::new();
+    let mut params = surrealdb::types::Array::new();
+    
+    for (k, v) in map {
+        if let Some(key) = k.as_text() {
+            match key {
+                "method" => {
+                    method = v.as_text().unwrap_or("").to_string();
+                }
+                "params" => {
+                    if let Some(arr) = v.as_array() {
+                        for item in arr {
+                            params.push(cbor_to_value(item));
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    
+    Ok((method, params))
+}
+
+fn cbor_to_value(v: &ciborium::Value) -> sdbValue {
+    match v {
+        ciborium::Value::Null => sdbValue::Null,
+        ciborium::Value::Bool(b) => sdbValue::Bool(*b),
+        ciborium::Value::Integer(i) => {
+            let n: i128 = (*i).into();
+            sdbValue::Number(surrealdb::types::Number::Int(n as i64))
+        }
+        ciborium::Value::Float(f) => sdbValue::Number(surrealdb::types::Number::Float(*f)),
+        ciborium::Value::Text(s) => sdbValue::String(s.clone()),
+        ciborium::Value::Bytes(b) => sdbValue::Bytes(surrealdb::types::Bytes::from(b.clone())),
+        ciborium::Value::Array(arr) => {
+            let vals: Vec<sdbValue> = arr.iter().map(cbor_to_value).collect();
+            sdbValue::Array(surrealdb::types::Array::from(vals))
+        }
+        ciborium::Value::Map(map) => {
+            let mut obj = surrealdb::types::Object::new();
+            for (k, v) in map {
+                if let Some(key) = k.as_text() {
+                    obj.insert(key.to_string(), cbor_to_value(v));
+                }
+            }
+            sdbValue::Object(obj)
+        }
+        _ => sdbValue::None,
+    }
+}
+
+pub(crate) fn value_to_cbor(v: &sdbValue) -> ciborium::Value {
+    match v {
+        sdbValue::None => ciborium::Value::Null,
+        sdbValue::Null => ciborium::Value::Null,
+        sdbValue::Bool(b) => ciborium::Value::Bool(*b),
+        sdbValue::Number(n) => match n {
+            surrealdb::types::Number::Int(i) => ciborium::Value::Integer((*i).into()),
+            surrealdb::types::Number::Float(f) => ciborium::Value::Float(*f),
+            surrealdb::types::Number::Decimal(d) => ciborium::Value::Text(d.to_string()),
+        },
+        sdbValue::String(s) => ciborium::Value::Text(s.clone()),
+        sdbValue::Array(arr) => {
+            ciborium::Value::Array(arr.iter().map(value_to_cbor).collect())
+        }
+        sdbValue::Object(obj) => {
+            let entries: Vec<(ciborium::Value, ciborium::Value)> = obj.iter()
+                .map(|(k, v)| (ciborium::Value::Text(k.clone()), value_to_cbor(v)))
+                .collect();
+            ciborium::Value::Map(entries)
+        }
+        _ => ciborium::Value::Text(format!("{v:?}")),
     }
 }
 
@@ -288,43 +345,30 @@ where
 #[allow(dead_code)]
 struct SurrealRpcInner {
     kvs: Datastore,
-    sess: ArcSwap<Session>,
-    lock: Arc<Semaphore>,
-    vars: BTreeMap<String, sql::Value>,
+    session_map: HashMap<Option<uuid::Uuid>, Arc<RwLock<Session>>>,
 }
 
-
-impl SurrealRpcInner {
-
-}
-
-impl RpcContext for SurrealRpcInner {
+impl RpcProtocol for SurrealRpcInner {
     fn kvs(&self) -> &Datastore {
         &self.kvs
     }
 
-    fn lock(&self) -> Arc<Semaphore> {
-        self.lock.clone()   
+    fn session_map(&self) -> &HashMap<Option<uuid::Uuid>, Arc<RwLock<Session>>> {
+        &self.session_map
     }
 
-    fn session(&self) -> Arc<Session> {
-        self.sess.load().clone()
-    }
-
-    fn set_session(&self, session: Arc<Session>) {
-        self.sess.store(session);
-    }
-    fn version_data(&self) -> Data {
+    fn version_data(&self) -> DbResult {
         let ver_str = surrealdb_core::env::VERSION.to_string();
-        ver_str.into()
+        DbResult::Other(sdbValue::String(ver_str))
     }
     
     const LQ_SUPPORT: bool = true;
 
-    async fn handle_live(&self, _lqid: &uuid::Uuid) {}
+    async fn handle_live(&self, _lqid: &uuid::Uuid, _session_id: Option<uuid::Uuid>) {}
 
     async fn handle_kill(&self, _lqid: &uuid::Uuid) {}
-}
 
-impl RpcProtocolV1 for SurrealRpcInner{}
-impl RpcProtocolV2 for SurrealRpcInner{}
+    async fn cleanup_lqs(&self, _session_id: Option<&uuid::Uuid>) {}
+
+    async fn cleanup_all_lqs(&self) {}
+}

--- a/src/types/array.rs
+++ b/src/types/array.rs
@@ -3,7 +3,7 @@ use std::{
     ptr::{self, slice_from_raw_parts, slice_from_raw_parts_mut},
 };
 
-use surrealdb::sql;
+use surrealdb::types::{Array as sdbArray, Value as sdbValue};
 use super::value::Value;
 
 #[repr(C)]
@@ -95,26 +95,25 @@ pub struct Array {
     pub len: c_int,
 }
 
-impl From<sql::Array> for Array {
-    fn from(value: sql::Array) -> Self {
-        let val_vec: Vec<Value> = value.0.into_iter().map(Into::into).collect();
+impl From<sdbArray> for Array {
+    fn from(value: sdbArray) -> Self {
+        let val_vec: Vec<Value> = value.into_iter().map(|v| Value::from(v)).collect();
         val_vec.into()
     }
 }
 
-impl From<&sql::Array> for Array {
-    fn from(value: &sql::Array) -> Self {
-        let val_vec: Vec<Value> = value.0.iter().map(Into::into).collect();
+impl From<&sdbArray> for Array {
+    fn from(value: &sdbArray) -> Self {
+        let val_vec: Vec<Value> = value.iter().map(|v| Value::from(v.clone())).collect();
         val_vec.into()
     }
 }
 
-impl From<Array> for sql::Array {
+impl From<Array> for sdbArray {
     fn from(value: Array) -> Self {
         let gen_arr: ArrayGen<Value> = value.into();
-        let vec: Vec<sql::Value> = gen_arr.into_vec().into_iter().map(Into::into).collect();
-
-        Self::from(vec)
+        let vec: Vec<sdbValue> = gen_arr.into_vec().into_iter().map(|v| sdbValue::from(v)).collect();
+        sdbArray::from(vec)
     }
 }
 
@@ -134,7 +133,6 @@ impl From<ArrayGen<Value>> for Array {
 impl From<Array> for ArrayGen<Value> {
     fn from(value: Array) -> Self {
         let result = ArrayGen { ptr: value.arr, len: value.len };
-        // Prevent Array's Drop from running to avoid double-free
         std::mem::forget(value);
         result
     }

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -1,6 +1,6 @@
 use std::{ffi::c_int, ptr::slice_from_raw_parts};
 
-use surrealdb::sql::Bytes as sdbBytes;
+use surrealdb::types::Bytes as sdbBytes;
 
 use super::array::{ArrayGen, MakeArray};
 
@@ -31,7 +31,7 @@ impl Bytes {
 
     #[export_name = "sr_free_byte_arr"]
     pub extern "C" fn free_byte_arr(ptr: *mut u8, len: c_int) {
-        ArrayGen { ptr: ptr, len: len }.free()
+        ArrayGen { ptr, len }.free()
     }
 }
 
@@ -66,12 +66,14 @@ impl From<Bytes> for ArrayGen<u8> {
 
 impl From<sdbBytes> for Bytes {
     fn from(value: sdbBytes) -> Self {
-        value.into_inner().make_array().into()
+        let vec: Vec<u8> = value.as_ref().to_vec();
+        vec.make_array().into()
     }
 }
 
 impl From<Bytes> for sdbBytes {
     fn from(value: Bytes) -> Self {
-        ArrayGen::from(value).into_vec().into()
+        let vec = ArrayGen::from(value).into_vec();
+        sdbBytes::from(vec)
     }
 }

--- a/src/types/duration.rs
+++ b/src/types/duration.rs
@@ -1,4 +1,5 @@
-use surrealdb::sql;
+use surrealdb::types::Duration as sdbDuration;
+
 #[derive(Debug, Clone, PartialEq)]
 #[repr(C)]
 pub struct Duration {
@@ -15,13 +16,14 @@ impl From<std::time::Duration> for Duration {
     }
 }
 
-impl From<surrealdb::sql::Duration> for Duration {
-    fn from(value: surrealdb::sql::Duration) -> Self {
-        value.0.into()
+impl From<sdbDuration> for Duration {
+    fn from(value: sdbDuration) -> Self {
+        let std_dur: std::time::Duration = value.into();
+        std_dur.into()
     }
 }
 
-impl From<Duration> for sql::Duration {
+impl From<Duration> for sdbDuration {
     fn from(value: Duration) -> Self {
         std::time::Duration::new(value.secs, value.nanos).into()
     }

--- a/src/types/geometry.rs
+++ b/src/types/geometry.rs
@@ -1,5 +1,5 @@
 use std::fmt::Debug;
-use surrealdb::sql::Geometry;
+use surrealdb::types::Geometry;
 use geo_types::{Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, Coord};
 use crate::array::*;
 use crate::value::Value;
@@ -189,7 +189,6 @@ impl From<sr_geometry> for Geometry {
             sr_geometry::sr_g_collection(c) => Geometry::Collection(
                 c.as_slice().iter().cloned().map(|g| Geometry::from(g)).collect()
             ),
-            // Unimplemented geometry converts to empty point as fallback
             sr_geometry::sr_g_unimplemented => Geometry::Point(Point::new(0.0, 0.0)),
         }
     }
@@ -207,7 +206,6 @@ impl From<Geometry> for sr_geometry {
             Geometry::Collection(c) => sr_geometry::sr_g_collection(
                 c.into_iter().map(|g| g.into()).collect::<Vec<sr_geometry>>().make_array()
             ),
-            // New geometry variants added to SurrealDB that aren't yet supported
             _ => sr_geometry::sr_g_unimplemented,
         }
     }
@@ -217,7 +215,6 @@ impl From<Value> for sr_geometry {
     fn from(value: Value) -> Self {
         match value {
             Value::SR_GEOMETRY_OBJECT(g) => g,
-            // Non-geometry value passed where geometry expected - return unimplemented marker
             _ => sr_geometry::sr_g_unimplemented,
         }
     }

--- a/src/types/notification.rs
+++ b/src/types/notification.rs
@@ -1,6 +1,5 @@
 use crate::{uuid::Uuid, value::Value};
-use surrealdb::Value as apiValue;
-use surrealdb::{sql, Notification as sdbNotification};
+use surrealdb::types::{Action as sdbAction, Notification as sdbNotification};
 
 #[derive(Debug)]
 #[repr(C)]
@@ -10,22 +9,14 @@ pub struct Notification {
     pub data: Value,
 }
 
-impl From<sdbNotification<apiValue>> for Notification {
-    fn from(value: sdbNotification<apiValue>) -> Self {
+/// Convert from the protocol-level Notification (surrealdb_types::Notification)
+/// Used by the RPC notification stream path.
+impl From<sdbNotification> for Notification {
+    fn from(value: sdbNotification) -> Self {
         Notification {
-            query_id: value.query_id.into(),
+            query_id: value.id.into(),
             action: value.action.into(),
-            data: (&value.data).into(),
-        }
-    }
-}
-
-impl From<sdbNotification<sql::Value>> for Notification {
-    fn from(value: sdbNotification<sql::Value>) -> Self {
-        Notification {
-            query_id: value.query_id.into(),
-            action: value.action.into(),
-            data: value.data.into(),
+            data: Value::from(value.result),
         }
     }
 }
@@ -44,18 +35,17 @@ pub enum Action {
     SR_ACTION_CREATE,
     SR_ACTION_UPDATE,
     SR_ACTION_DELETE,
-    /// Represents an action type added in a newer version of SurrealDB
-    /// that this C API version doesn't yet support
-    SR_ACTION_UNIMPLEMENTED,
+    SR_ACTION_KILLED,
 }
 
-impl From<surrealdb::Action> for Action {
-    fn from(value: surrealdb::Action) -> Self {
+impl From<sdbAction> for Action {
+    fn from(value: sdbAction) -> Self {
         match value {
-            surrealdb::Action::Create => Action::SR_ACTION_CREATE,
-            surrealdb::Action::Update => Action::SR_ACTION_UPDATE,
-            surrealdb::Action::Delete => Action::SR_ACTION_DELETE,
-            _ => Action::SR_ACTION_UNIMPLEMENTED,
+            sdbAction::Create => Action::SR_ACTION_CREATE,
+            sdbAction::Update => Action::SR_ACTION_UPDATE,
+            sdbAction::Delete => Action::SR_ACTION_DELETE,
+            sdbAction::Killed => Action::SR_ACTION_KILLED,
+            _ => Action::SR_ACTION_KILLED,
         }
     }
 }

--- a/src/types/number.rs
+++ b/src/types/number.rs
@@ -1,6 +1,6 @@
 use std::ffi::{c_double, c_float, c_int, CStr};
 
-use surrealdb::sql;
+use surrealdb::types::Number as sdbNumber;
 use rust_decimal::Decimal;
 use crate::string::string_t;
 use crate::utils::CStringExt2;
@@ -39,18 +39,18 @@ impl From<Decimal> for Number {
     }
 }
 
-impl From<Number> for sql::Number {
+impl From<Number> for sdbNumber {
     fn from(value: Number) -> Self {
         match value {
-            Number::SR_NUMBER_INT(i) => sql::Number::Int(i),
-            Number::SR_NUMBER_FLOAT(f) => sql::Number::Float(f),
+            Number::SR_NUMBER_INT(i) => sdbNumber::Int(i),
+            Number::SR_NUMBER_FLOAT(f) => sdbNumber::Float(f),
             Number::SR_NUMBER_DECIMAL(s) => {
                 let cstr = unsafe { CStr::from_ptr(s.0) };
                 let decimal_str = cstr.to_string_lossy();
                 match decimal_str.parse::<Decimal>() {
-                    Ok(d) => sql::Number::Decimal(d),
+                    Ok(d) => sdbNumber::Decimal(d),
                     // Fallback to float if parsing fails
-                    Err(_) => sql::Number::Float(decimal_str.parse().unwrap_or(0.0)),
+                    Err(_) => sdbNumber::Float(decimal_str.parse().unwrap_or(0.0)),
                 }
             }
         }

--- a/src/types/object.rs
+++ b/src/types/object.rs
@@ -3,7 +3,7 @@ use std::{
     ffi::{c_char, c_double, c_float, c_int, CStr},
 };
 
-use surrealdb::sql;
+use surrealdb::types::{Object as sdbObject, Value as sdbValue};
 
 use crate::{utils::CStringExt2, value::Value};
 
@@ -154,7 +154,6 @@ impl Object {
             return 0;
         }
         
-        // Allocate array for the pointers
         let boxed = keys.into_boxed_slice();
         let ptr = Box::into_raw(boxed) as *mut *mut c_char;
         unsafe { *keys_ptr = ptr; }
@@ -176,35 +175,33 @@ impl Object {
             }
         }
         
-        // Free the array itself
         let _ = unsafe { Box::from_raw(std::slice::from_raw_parts_mut(arr, len as usize) as *mut [*mut c_char]) };
     }
 }
 
-impl From<sql::Object> for Object {
-    fn from(value: sql::Object) -> Self {
-        let map = value.0;
+impl From<sdbObject> for Object {
+    fn from(value: sdbObject) -> Self {
         let out = Self(Box::new(
-            map.into_iter().map(|(k, v)| (k, v.into())).collect(),
+            value.into_iter().map(|(k, v)| (k, Value::from(v))).collect(),
         ));
         out
     }
 }
 
-impl From<&sql::Object> for Object {
-    fn from(value: &sql::Object) -> Self {
-        let map = &value.0;
+impl From<&sdbObject> for Object {
+    fn from(value: &sdbObject) -> Self {
         let out = Self(Box::new(
-            map.iter().map(|(k, v)| (k.to_owned(), v.into())).collect(),
+            value.iter().map(|(k, v)| (k.to_owned(), Value::from(v.clone()))).collect(),
         ));
         out
     }
 }
-impl From<Object> for sql::Object {
+
+impl From<Object> for sdbObject {
     fn from(value: Object) -> Self {
         let map = value.0;
-        let out: BTreeMap<String, sql::Value> =
-            map.into_iter().map(|(k, v)| (k, v.into())).collect();
-        out.into()
+        let entries: BTreeMap<String, sdbValue> =
+            map.into_iter().map(|(k, v)| (k, sdbValue::from(v))).collect();
+        sdbObject::from(entries)
     }
 }

--- a/src/types/stream.rs
+++ b/src/types/stream.rs
@@ -3,9 +3,7 @@ use std::ffi::c_int;
 use async_channel::Receiver;
 use futures::StreamExt;
 use surrealdb::method::Stream as sdbStream;
-use surrealdb::rpc::format::cbor::Cbor;
-use surrealdb::Value as apiValue;
-use surrealdb::{dbs, sql};
+use surrealdb::types::{Value as sdbValue, Notification as PublicNotification};
 use tokio::runtime::Handle;
 
 use crate::SR_ERROR;
@@ -18,27 +16,47 @@ use super::array::MakeArray;
 /// May be sent across threads, but must not be aliased.
 /// Use `sr_stream_next` to receive notifications and `sr_stream_kill` to close.
 pub struct Stream {
-    inner: sdbStream<apiValue>,
+    inner: sdbStream<sdbValue>,
     rt: Handle,
 }
 
 impl Stream {
-    pub fn new(inner: sdbStream<apiValue>, rt: Handle) -> Stream {
+    pub fn new(inner: sdbStream<sdbValue>, rt: Handle) -> Stream {
         Stream { inner, rt }
     }
 }
 
 impl Stream {
     /// Blocks until next item is received on stream
-    /// will return 1 and write notification to notification_ptr is recieved
+    /// will return 1 and write notification to notification_ptr if received
     /// will return SR_NONE if the stream is closed
+    ///
+    /// sr_stream_t *stream;
+    /// if (sr_select_live(db, &err, &stream, "foo") < 0)
+    /// {
+    ///     printf("%s", err);
+    ///     return 1;
+    /// }
+    ///
+    /// sr_notification_t not ;
+    /// if (sr_stream_next(stream, &not ) > 0)
+    /// {
+    ///     sr_print_notification(&not );
+    /// }
+    /// sr_stream_kill(stream);
     #[export_name = "sr_stream_next"]
     pub extern "C" fn next(&mut self, notification_ptr: *mut Notification) -> c_int {
         match self.rt.block_on(self.inner.next()) {
-            Some(n) => {
-                unsafe { notification_ptr.write(n.into()) }
+            Some(Ok(n)) => {
+                let notif = Notification {
+                    query_id: crate::uuid::Uuid::from(n.query_id),
+                    action: crate::notification::Action::from(n.action),
+                    data: crate::value::Value::from(n.data),
+                };
+                unsafe { notification_ptr.write(notif) }
                 1
             }
+            Some(Err(_)) => SR_ERROR,
             None => SR_NONE,
         }
     }
@@ -55,42 +73,47 @@ impl Stream {
     }
 }
 
-/// Stream for receiving RPC notifications
+/// Stream for receiving RPC live query notifications
 ///
+/// Wraps a `Receiver<PublicNotification>` from the datastore's notification channel.
 /// Uses synchronous blocking receives, so no async drop is required.
 pub struct RpcStream {
-    rx: Receiver<dbs::Notification>,
+    rx: Receiver<PublicNotification>,
 }
 
 impl RpcStream {
     /// Create a new RpcStream from a notification receiver
-    pub fn new(rx: Receiver<dbs::Notification>) -> Self {
+    pub fn new(rx: Receiver<PublicNotification>) -> Self {
         RpcStream { rx }
     }
 
     /// Get the next notification from the stream
-    /// Returns the length of the CBOR-encoded notification, or SR_CLOSED if the stream is closed
+    ///
+    /// Returns the length of the CBOR-encoded notification, or SR_CLOSED if the
+    /// channel is closed. The CBOR-encoded bytes are written to *res_ptr.
+    ///
+    /// Free the result with sr_free_byte_arr.
     #[export_name = "sr_rpc_stream_next"]
     pub extern "C" fn next(&mut self, res_ptr: *mut *mut u8) -> c_int {
-        let not = match self.rx.recv_blocking() {
+        let notification = match self.rx.recv_blocking() {
             Ok(n) => n,
             Err(_) => return SR_CLOSED,
         };
 
-        // Construct live message
-        let mut message = sql::Object::default();
-        message.insert("id".to_string(), not.id.into());
-        message.insert("action".to_string(), not.action.to_string().into());
-        message.insert("result".to_string(), not.result);
+        let mut obj = surrealdb::types::Object::new();
+        obj.insert(
+            "id".to_string(),
+            sdbValue::Uuid(notification.id),
+        );
+        obj.insert(
+            "action".to_string(),
+            sdbValue::String(format!("{}", notification.action)),
+        );
+        obj.insert("result".to_string(), notification.result);
 
-        // Into CBOR value
-        let cbor: Cbor = match sql::Value::Object(message).try_into() {
-            Ok(c) => c,
-            Err(_) => return SR_ERROR,
-        };
-
+        let cbor_val = crate::rpc::value_to_cbor(&sdbValue::Object(obj));
         let mut res = Vec::new();
-        if ciborium::into_writer(&cbor.0, &mut res).is_err() {
+        if ciborium::into_writer(&cbor_val, &mut res).is_err() {
             return SR_ERROR;
         }
         let out = res.make_array();

--- a/src/types/thing.rs
+++ b/src/types/thing.rs
@@ -1,6 +1,6 @@
 use std::{ffi::CString, fmt::Debug};
 
-use surrealdb::sql;
+use surrealdb::types::{RecordId, RecordIdKey};
 
 use crate::{array::Array, object::Object, string::string_t, utils::CStringExt2};
 
@@ -17,26 +17,19 @@ pub struct Thing {
 pub enum Id {
     SR_ID_NUMBER(i64),
     SR_ID_STRING(string_t),
-    // unnesessary Box, but breaks header gen
     SR_ID_ARRAY(Box<Array>),
     SR_ID_OBJECT(Object),
-    // Generate(Gen),
 }
 
-impl From<sql::Thing> for Thing {
-    fn from(value: sql::Thing) -> Self {
-        // Handle null bytes gracefully - use empty string as fallback
-        let str_ptr = CString::new(value.tb).unwrap_or_else(|_| CString::new("").unwrap()).into_raw();
-        let id = match value.id {
-            sql::Id::Number(i) => Id::SR_ID_NUMBER(i),
-            sql::Id::String(s) => Id::SR_ID_STRING(s.to_string_t()),
-            sql::Id::Array(a) => Id::SR_ID_ARRAY(Box::new(a.into())),
-            sql::Id::Object(o) => Id::SR_ID_OBJECT(o.into()),
-            sql::Id::Generate(g) => {
-                // Convert generated ID to string representation using Debug
-                Id::SR_ID_STRING(format!("{:?}", g).to_string_t())
-            }
-            // Handle Range and any other new variants by converting to string
+impl From<RecordId> for Thing {
+    fn from(value: RecordId) -> Self {
+        let table_str = value.table.to_string();
+        let str_ptr = CString::new(table_str).unwrap_or_else(|_| CString::new("").unwrap()).into_raw();
+        let id = match value.key {
+            RecordIdKey::Number(i) => Id::SR_ID_NUMBER(i),
+            RecordIdKey::String(s) => Id::SR_ID_STRING(s.to_string_t()),
+            RecordIdKey::Array(a) => Id::SR_ID_ARRAY(Box::new(Array::from(a))),
+            RecordIdKey::Object(o) => Id::SR_ID_OBJECT(Object::from(o)),
             other => Id::SR_ID_STRING(format!("{:?}", other).to_string_t()),
         };
         Self {
@@ -46,39 +39,24 @@ impl From<sql::Thing> for Thing {
     }
 }
 
-impl From<&sql::Thing> for Thing {
-    fn from(value: &sql::Thing) -> Self {
-        // Handle null bytes gracefully - use empty string as fallback
-        let str_ptr = CString::new(value.tb.clone()).unwrap_or_else(|_| CString::new("").unwrap()).into_raw();
-        let id = match &value.id {
-            sql::Id::Number(i) => Id::SR_ID_NUMBER(*i),
-            sql::Id::String(s) => Id::SR_ID_STRING(s.as_str().to_string_t()),
-            sql::Id::Array(a) => Id::SR_ID_ARRAY(Box::new(a.into())),
-            sql::Id::Object(o) => Id::SR_ID_OBJECT(o.into()),
-            sql::Id::Generate(g) => {
-                // Convert generated ID to string representation using Debug
-                Id::SR_ID_STRING(format!("{:?}", g).to_string_t())
-            }
-            // Handle Range and any other new variants by converting to string
-            other => Id::SR_ID_STRING(format!("{:?}", other).to_string_t()),
-        };
-        Self {
-            table: string_t(str_ptr),
-            id,
-        }
+impl From<&RecordId> for Thing {
+    fn from(value: &RecordId) -> Self {
+        Self::from(value.clone())
     }
 }
 
-impl From<Thing> for sql::Thing {
+impl From<Thing> for RecordId {
     fn from(value: Thing) -> Self {
         let table = String::from(value.table);
-        let id = match value.id {
-            Id::SR_ID_NUMBER(i) => sql::Id::Number(i),
-            Id::SR_ID_STRING(s) => sql::Id::String(s.into()),
-            Id::SR_ID_ARRAY(a) => sql::Id::Array((*a).into()),
-            Id::SR_ID_OBJECT(o) => sql::Id::Object(o.into()),
+        let key = match value.id {
+            Id::SR_ID_NUMBER(i) => RecordIdKey::Number(i),
+            Id::SR_ID_STRING(s) => RecordIdKey::String(s.into()),
+            Id::SR_ID_ARRAY(a) => RecordIdKey::Array((*a).into()),
+            Id::SR_ID_OBJECT(o) => RecordIdKey::Object(o.into()),
         };
-
-        (table, id).into()
+        RecordId {
+            table: table.into(),
+            key,
+        }
     }
 }

--- a/src/types/uuid.rs
+++ b/src/types/uuid.rs
@@ -1,4 +1,4 @@
-use surrealdb::sql::Uuid as sdbUuid;
+use surrealdb::types::Uuid as sdbUuid;
 
 #[repr(C)]
 #[derive(Debug, Clone, PartialEq)]
@@ -6,8 +6,8 @@ pub struct Uuid(pub [u8; 16]);
 
 impl From<sdbUuid> for Uuid {
     fn from(value: sdbUuid) -> Self {
-        let bytes = value.0.into_bytes();
-        Self(bytes)
+        let inner: uuid::Uuid = value.into();
+        Self(inner.into_bytes())
     }
 }
 
@@ -26,6 +26,6 @@ impl From<Uuid> for uuid::Uuid {
 impl From<Uuid> for sdbUuid {
     fn from(value: Uuid) -> Self {
         let tmp: uuid::Uuid = value.into();
-        tmp.into()
+        sdbUuid::from(tmp)
     }
 }

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -1,8 +1,9 @@
 use std::ffi::CStr;
 
 use chrono::DateTime;
-use surrealdb_core::sql;
-use surrealdb_core::sql::Value as sdbValue;
+use surrealdb::types::{
+    Value as sdbValue, Number as sdbNumber,
+};
 
 pub use crate::{array::Array, number::Number, object::Object, geometry::sr_geometry};
 use crate::{bytes::Bytes, string::string_t, thing::Thing, utils::CStringExt2, uuid::Uuid};
@@ -53,26 +54,22 @@ impl From<sdbValue> for Value {
             sdbValue::Null => Value::SR_VALUE_NULL,
             sdbValue::Bool(b) => Value::SR_VALUE_BOOL(b),
             sdbValue::Number(n) => match n {
-                sql::Number::Int(i) => Value::SR_VALUE_NUMBER(Number::SR_NUMBER_INT(i)),
-                sql::Number::Float(f) => Value::SR_VALUE_NUMBER(Number::SR_NUMBER_FLOAT(f)),
-                sql::Number::Decimal(d) => Value::SR_VALUE_NUMBER(Number::from(d)),
+                sdbNumber::Int(i) => Value::SR_VALUE_NUMBER(Number::SR_NUMBER_INT(i)),
+                sdbNumber::Float(f) => Value::SR_VALUE_NUMBER(Number::SR_NUMBER_FLOAT(f)),
+                sdbNumber::Decimal(d) => Value::SR_VALUE_NUMBER(Number::from(d)),
                 _ => {
-                    // Handle any new Number variants by converting to string representation
                     Value::SR_VALUE_NUMBER(Number::SR_NUMBER_FLOAT(0.0))
                 }
             },
-            sdbValue::Strand(s) => Value::SR_VALUE_STRAND(s.0.to_string_t()),
-            sdbValue::Duration(d) => Value::SR_VALUE_DURATION(d.into()),
-            sdbValue::Datetime(dt) => Value::SR_VALUE_DATETIME(dt.to_rfc3339().to_string_t()),
-            sdbValue::Uuid(u) => Value::SR_VALUE_UUID(u.into()),
-            // unnecessary box see: https://github.com/mozilla/cbindgen/issues/981
+            sdbValue::String(s) => Value::SR_VALUE_STRAND(s.to_string_t()),
+            sdbValue::Duration(d) => Value::SR_VALUE_DURATION(Duration::from(std::time::Duration::from(d))),
+            sdbValue::Datetime(dt) => Value::SR_VALUE_DATETIME(dt.to_string().to_string_t()),
+            sdbValue::Uuid(u) => Value::SR_VALUE_UUID(Uuid(u.into_bytes())),
             sdbValue::Array(a) => Value::SR_VALUE_ARRAY(Box::new(a.into())),
             sdbValue::Object(o) => Value::SR_VALUE_OBJECT(o.into()),
             sdbValue::Geometry(g) => Value::SR_GEOMETRY_OBJECT(sr_geometry::from(g)),
-            sdbValue::Bytes(b) => Value::SR_VALUE_BYTES(b.into()),
-            sdbValue::Thing(t) => Value::SR_VALUE_THING(t.into()),
-            // Other variants are internal/computed and shouldn't appear in query results
-            // If they do, we convert to None to avoid panics
+            sdbValue::Bytes(b) => Value::SR_VALUE_BYTES(Bytes::from(b)),
+            sdbValue::RecordId(r) => Value::SR_VALUE_THING(Thing::from(r)),
             _ => Value::SR_VALUE_NONE,
         }
     }
@@ -80,43 +77,6 @@ impl From<sdbValue> for Value {
 
 impl From<&sdbValue> for Value {
     fn from(value: &sdbValue) -> Self {
-        match value {
-            sdbValue::None => Value::SR_VALUE_NONE,
-            sdbValue::Null => Value::SR_VALUE_NULL,
-            sdbValue::Bool(b) => Value::SR_VALUE_BOOL(*b),
-            sdbValue::Number(n) => match n {
-                sql::Number::Int(i) => Value::SR_VALUE_NUMBER(Number::SR_NUMBER_INT(*i)),
-                sql::Number::Float(f) => Value::SR_VALUE_NUMBER(Number::SR_NUMBER_FLOAT(*f)),
-                sql::Number::Decimal(d) => Value::SR_VALUE_NUMBER(Number::from(*d)),
-                _ => {
-                    // Handle any new Number variants
-                    Value::SR_VALUE_NUMBER(Number::SR_NUMBER_FLOAT(0.0))
-                }
-            },
-            sdbValue::Strand(s) => Value::SR_VALUE_STRAND(s.0.as_str().to_string_t()),
-            sdbValue::Duration(d) => Value::SR_VALUE_DURATION(d.clone().into()),
-            sdbValue::Datetime(dt) => Value::SR_VALUE_DATETIME(dt.to_rfc3339().to_string_t()),
-            sdbValue::Uuid(u) => Value::SR_VALUE_UUID(u.clone().into()),
-            // unnecessary box see: https://github.com/mozilla/cbindgen/issues/981
-            sdbValue::Array(a) => Value::SR_VALUE_ARRAY(Box::new(a.into())),
-            sdbValue::Object(o) => Value::SR_VALUE_OBJECT(o.into()),
-            sdbValue::Geometry(g) => Value::SR_GEOMETRY_OBJECT(sr_geometry::from(g.clone())),
-            sdbValue::Bytes(b) => Value::SR_VALUE_BYTES(b.clone().into()),
-            sdbValue::Thing(t) => Value::SR_VALUE_THING(t.into()),
-            // Other variants are internal/computed and shouldn't appear in query results
-            _ => Value::SR_VALUE_NONE,
-        }
-    }
-}
-impl From<surrealdb::Value> for Value {
-    fn from(value: surrealdb::Value) -> Self {
-        let value: sdbValue = value.into_inner();
-        Self::from(value)
-    }
-}
-impl From<&surrealdb::Value> for Value {
-    fn from(value: &surrealdb::Value) -> Self {
-        // Clone the value to safely convert without relying on internal layout assumptions
         Self::from(value.clone())
     }
 }
@@ -128,23 +88,27 @@ impl From<Value> for sdbValue {
             Value::SR_VALUE_NULL => sdbValue::Null,
             Value::SR_VALUE_BOOL(b) => sdbValue::Bool(b),
             Value::SR_VALUE_NUMBER(n) => sdbValue::Number(n.into()),
-            Value::SR_VALUE_STRAND(s) => sdbValue::Strand(String::from(s).into()),
-            Value::SR_VALUE_DURATION(d) => sdbValue::Duration(d.into()),
+            Value::SR_VALUE_STRAND(s) => sdbValue::String(String::from(s)),
+            Value::SR_VALUE_DURATION(d) => {
+                let std_dur = std::time::Duration::new(d.secs, d.nanos);
+                sdbValue::Duration(std_dur.into())
+            }
             Value::SR_VALUE_DATETIME(d) => {
                 let cstr = unsafe { CStr::from_ptr(d.0) };
-                sdbValue::Datetime(
-                    DateTime::parse_from_rfc3339(cstr.to_string_lossy().as_ref())
-                        .unwrap_or_default()
-                        .to_utc()
-                        .into(),
-                )
+                let parsed = DateTime::parse_from_rfc3339(cstr.to_string_lossy().as_ref())
+                    .unwrap_or_default()
+                    .to_utc();
+                sdbValue::Datetime(parsed.into())
             }
-            Value::SR_VALUE_UUID(u) => sdbValue::Uuid(u.into()),
+            Value::SR_VALUE_UUID(u) => {
+                let uuid_val: uuid::Uuid = u.into();
+                sdbValue::Uuid(uuid_val.into())
+            }
             Value::SR_VALUE_ARRAY(a) => sdbValue::Array((*a).into()),
             Value::SR_VALUE_OBJECT(o) => sdbValue::Object(o.into()),
             Value::SR_GEOMETRY_OBJECT(g) => sdbValue::Geometry(g.into()),
             Value::SR_VALUE_BYTES(b) => sdbValue::Bytes(b.into()),
-            Value::SR_VALUE_THING(t) => sdbValue::Thing(t.into()),
+            Value::SR_VALUE_THING(t) => sdbValue::RecordId(t.into()),
         }
     }
 }


### PR DESCRIPTION
This aims to add initial support for SurrealDB v3 while maintaining backward compatibility.

I mainly use surrealdb.c via CGO. The same Go code worked with and without the changes introduced in this pull request.

This has some extras like `c_test/examples/v3_smoke_test.c` for quick automated smoke testing and `scripts/install-prereqs.sh` for ease of initial build setup- hope you like it.