### PR TITLE
Fix build on Rust 1.94+ by increasing recursion_limit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 pub mod opts;
 pub mod rpc;
 pub mod types;


### PR DESCRIPTION
Rust 1.94 might have changed how it resolves async type layouts, causing surrealdb_core::expr::expression::Expr::compute() to exceed the default recursion limit of 128. This adds #![recursion_limit = "256"] to the crate root.

More concretely, this fixes the error below, which occurs 100% of the time when you try to build surrealdb.c with Rust 1.94.0.
Without this fix, you cannot build it:

```
error: queries overflow the depth limit!
  |
  = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`surrealdb_c`)
  = note: query depth increased by 130 when computing layout of `{async fn body of surrealdb_core::expr::expression::Expr::compute()}`

warning: `surrealdb_c` (lib) generated 3 warnings
error: could not compile `surrealdb_c` (lib) due to 1 previous error; 3 warnings emitted
```
